### PR TITLE
feat(meta): Allow Account Changing

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can connect directly to this endpoint when using the MCP HTTP transport mode
 
 The server implements comprehensive coverage of the Fakturoid API:
 
-- **Account Management** - Get and update account information
+- **Account Management** - Get and update account information, including multi-account support via switching using the `Change the Active Fakturoid Account` tool
 - **Invoice Operations** - Full CRUD operations, search, filtering, and PDF generation
 - **Expense Tracking** - Create, read, update, delete, and categorize expenses
 - **Contact Management** - Manage subjects (companies and individuals)

--- a/src/fakturoid/client.ts
+++ b/src/fakturoid/client.ts
@@ -10,6 +10,7 @@ import type { InvoiceMessage } from "./model/invoiceMessage.js";
 import type { CreateInvoicePayment } from "./model/invoicePayment.js";
 import type { CreateRecurringGenerator, UpdateRecurringGenerator } from "./model/recurringGenerator.js";
 import type { GetSubjectsFilters, SubjectCreate, SubjectUpdate } from "./model/subject.js";
+import type { User } from "./model/user.js";
 import type { CreateWebhook, UpdateWebhook } from "./model/webhook.js";
 import { getAccountDetail } from "./client/account.js";
 import { getBankAccounts } from "./client/bankAccount.js";
@@ -84,7 +85,7 @@ import { createWebhook, deleteWebhook, getWebhook, getWebhooks, updateWebhook } 
 
 export class FakturoidClient<Configuration extends object, Strategy extends AuthenticationStrategy<Configuration>> {
 	private readonly strategy: Strategy;
-	private readonly accountSlug: string;
+	private accountSlug: string;
 
 	private constructor(strategy: Strategy, accountSlug: string) {
 		this.strategy = strategy;
@@ -100,8 +101,27 @@ export class FakturoidClient<Configuration extends object, Strategy extends Auth
 			throw new Error("The user account could not be found.");
 		}
 
+		// Default to the first available account slug. Can be changed via `changeAccountSlug`
 		return new FakturoidClient(strategy, user.accounts[0].slug);
 	}
+
+	getAvailableAccounts = async (): Promise<User["accounts"]> => {
+		const user = await getCurrentUser(this.strategy);
+		if (user instanceof Error) {
+			throw new Error("The user account could not be found.");
+		}
+
+		return user.accounts;
+	};
+
+	changeAccountSlug = async (accountSlug: string): Promise<void> => {
+		const availableSlugs = await this.getAvailableAccounts().then((accounts) => accounts.map(({ slug }) => slug));
+		if (!availableSlugs.includes(accountSlug)) {
+			throw new Error(`The account slug '${accountSlug}' is not available.`);
+		}
+
+		this.accountSlug = accountSlug;
+	};
 
 	// Account
 	getAccountDetail = () => getAccountDetail(this.strategy, this.accountSlug);

--- a/src/fakturoid/tool/meta.ts
+++ b/src/fakturoid/tool/meta.ts
@@ -1,0 +1,36 @@
+import z from "zod/v3";
+import { createTool, type ServerToolCreator } from "./common.js";
+
+const getAvailableAccounts = createTool(
+	"fakturoid_get_available_accounts",
+	"Get Available Fakturoid Accounts",
+	"Get the list of all available Fakturoid accounts.",
+	async (client) => {
+		const accounts = await client.getAvailableAccounts();
+
+		return {
+			content: [{ text: JSON.stringify(accounts, null, 2), type: "text" }],
+		};
+	},
+	{},
+);
+
+const changeActiveAccount = createTool(
+	"fakturoid_change_active_account",
+	"Change the Active Fakturoid Account",
+	"Change the account used to interact with the Fakturoid API using an account slug from the list of available accounts.",
+	async (client, { accountSlug }) => {
+		await client.changeAccountSlug(accountSlug);
+
+		return {
+			content: [{ text: "Account changed successfully", type: "text" }],
+		};
+	},
+	{
+		accountSlug: z.string().nonempty(),
+	},
+);
+
+const meta = [getAvailableAccounts, changeActiveAccount] as const satisfies ServerToolCreator[];
+
+export { meta };

--- a/src/fakturoid/tools.ts
+++ b/src/fakturoid/tools.ts
@@ -14,6 +14,7 @@ import { inventoryMove } from "./tool/inventoryMove.js";
 import { invoice } from "./tool/invoice.js";
 import { invoiceMessage } from "./tool/invoiceMessage.js";
 import { invoicePayment } from "./tool/invoicePayment.js";
+import { meta } from "./tool/meta.js";
 import { numberFormat } from "./tool/numberFormat.js";
 import { recurringGenerator } from "./tool/recurringGenerator.js";
 import { subject } from "./tool/subject.js";
@@ -41,6 +42,7 @@ const registerFakturoidTools = <
 		invoice,
 		invoiceMessage,
 		invoicePayment,
+		meta,
 		numberFormat,
 		recurringGenerator,
 		subject,

--- a/test/fakturoid/client.test.ts
+++ b/test/fakturoid/client.test.ts
@@ -1,0 +1,99 @@
+import type { User } from "../../src/fakturoid/model/user.js";
+import { afterEach, beforeEach, describe, expect, type Mock, test } from "vitest";
+import { FakturoidClient } from "../../src/fakturoid/client.js";
+import { createUser } from "../factory/user.factory.js";
+import { createResponse, mockFetch } from "../testUtils/mock.js";
+import { TestStrategy } from "../testUtils/strategy.js";
+
+describe("Fakturoid Client", () => {
+	let mockedFetch: Mock<typeof global.fetch>;
+	let strategy: TestStrategy;
+
+	beforeEach(() => {
+		mockedFetch = mockFetch();
+		strategy = new TestStrategy();
+	});
+
+	afterEach(() => {
+		mockedFetch.mockReset();
+	});
+
+	test("Get Available Accounts and Change Active Account", async () => {
+		const user: User = createUser("test-user", {
+			accounts: [
+				{
+					allowed_scope: ["invoices", "expenses"],
+					logo: "https://example.com/logo1.png",
+					name: "Test Company 1",
+					permission: "owner",
+					registration_no: "12345678",
+					slug: "test-company-1",
+				},
+				{
+					allowed_scope: ["invoices"],
+					logo: "https://example.com/logo2.png",
+					name: "Test Company 2",
+					permission: "admin",
+					registration_no: "87654321",
+					slug: "test-company-2",
+				},
+			],
+		});
+		mockedFetch.mockResolvedValueOnce(createResponse(user));
+
+		const client = await FakturoidClient.create(strategy);
+
+		expect(mockedFetch).toHaveBeenCalledWith("https://test.example/user.json", {
+			body: null,
+			headers: Object.fromEntries(
+				new Headers({
+					Authorization: `Bearer ${await strategy.getAccessToken()}`,
+					"Content-Type": "application/json",
+					"User-Agent": `${strategy.appName} (${await strategy.getContactEmail()})`,
+				}).entries(),
+			),
+			method: "GET",
+		});
+
+		mockedFetch.mockResolvedValueOnce(createResponse(user));
+
+		const availableAccounts = await client.getAvailableAccounts();
+
+		expect(availableAccounts).toStrictEqual(user.accounts);
+		expect(mockedFetch).toHaveBeenCalledWith("https://test.example/user.json", {
+			body: null,
+			headers: Object.fromEntries(
+				new Headers({
+					Authorization: `Bearer ${await strategy.getAccessToken()}`,
+					"Content-Type": "application/json",
+					"User-Agent": `${strategy.appName} (${await strategy.getContactEmail()})`,
+				}).entries(),
+			),
+			method: "GET",
+		});
+
+		mockedFetch.mockResolvedValueOnce(createResponse(user));
+
+		await client.changeAccountSlug("test-company-2");
+
+		expect(mockedFetch).toHaveBeenCalledWith("https://test.example/user.json", {
+			body: null,
+			headers: Object.fromEntries(
+				new Headers({
+					Authorization: `Bearer ${await strategy.getAccessToken()}`,
+					"Content-Type": "application/json",
+					"User-Agent": `${strategy.appName} (${await strategy.getContactEmail()})`,
+				}).entries(),
+			),
+			method: "GET",
+		});
+
+		mockedFetch.mockResolvedValueOnce(createResponse(user));
+
+		await expect(client.changeAccountSlug("invalid-slug")).rejects.toThrow(
+			"The account slug 'invalid-slug' is not available.",
+		);
+
+		expect(mockedFetch).toHaveBeenCalledTimes(4);
+	});
+});


### PR DESCRIPTION
- Implements #1 
- Allow account changing via an account slug
- Add two new tools
  - `fakturoid_get_available_accounts`
  - `fakturoid_change_active_account`
- Cover the new functionality with tests