### PR TITLE
fix(docs): Update README & Add LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,25 @@
+The MIT License (MIT)
+=====================
+
+Copyright © `<year>` `<copyright holders>`
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This MCP server provides a complete integration with Fakturoid API v3, demonstra
 - **📚 Resources** - 10 contextual data sources providing real-time business insights
 - **💡 Prompts** - 6 professional workflow templates for common accounting tasks
 
-👉 **Hosted deployment**:  
-The server is publicly available at **https://fakturoid-mcp.cookielab.ai** via CloudFront.  
+👉 **Hosted deployment**:
+The server is publicly available at **https://fakturoid-mcp.cookielab.ai** via Cloudflare Workers.
 You can connect directly to this endpoint when using the MCP HTTP transport mode
 
 ## Features
@@ -123,7 +123,7 @@ The server can be configured in Claude Desktop using any of the three transport 
    ```
 
 2. Choose your preferred transport mode and update the configuration:
-You can either run the server locally (e.g. `http://localhost:5173/mcp`) or connect directly to the **hosted deployment at https://fakturoid-mcp.cookielab.ai/mcp**.
+   You can either run the server locally (e.g. `http://localhost:5173/mcp`) or connect directly to the **hosted deployment at https://fakturoid-mcp.cookielab.ai/mcp**.
    **For STDIO mode (recommended for Claude Desktop):**
 
    ```json


### PR DESCRIPTION
1. Fix README with the correct deployment name
2. Add MIT License