### PR TITLE
fix: Resolve MCP STDIO logging conflicts and add FAKTUROID_ env prefix support

### DIFF
--- a/src/auth/localStrategy.ts
+++ b/src/auth/localStrategy.ts
@@ -22,22 +22,45 @@ const TokenResponseSchema = z
 
 const EnvironmentConfigurationSchema = z
 	.object({
-		API_URL: z.string().url(),
-		APP_NAME: z.string().min(1).default("FakturoidMCP"),
-		CLIENT_ID: z.string().min(1),
-		CLIENT_SECRET: z.string().min(1),
-		CONTACT_EMAIL: z.string().email().default("test@example.com"),
+		// Support both FAKTUROID_ prefixed and non-prefixed environment variables
+		API_URL: z.string().url().optional(),
+		FAKTUROID_API_URL: z.string().url().optional(),
+		APP_NAME: z.string().min(1).optional(),
+		FAKTUROID_APP_NAME: z.string().min(1).optional(),
+		CLIENT_ID: z.string().min(1).optional(),
+		FAKTUROID_CLIENT_ID: z.string().min(1).optional(),
+		CLIENT_SECRET: z.string().min(1).optional(),
+		FAKTUROID_CLIENT_SECRET: z.string().min(1).optional(),
+		CONTACT_EMAIL: z.string().email().optional(),
+		FAKTUROID_CONTACT_EMAIL: z.string().email().optional(),
+		ACCOUNT_SLUG: z.string().min(1).optional(),
+		FAKTUROID_ACCOUNT_SLUG: z.string().min(1).optional(),
 	})
-	.transform(
-		(parsed) =>
-			({
-				appName: parsed.APP_NAME,
-				baseURL: parsed.API_URL,
-				clientID: parsed.CLIENT_ID,
-				clientSecret: parsed.CLIENT_SECRET,
-				email: parsed.CONTACT_EMAIL,
-			}) satisfies Configuration,
-	);
+	.transform((parsed) => {
+		const apiUrl = parsed.FAKTUROID_API_URL ?? parsed.API_URL;
+		const clientId = parsed.FAKTUROID_CLIENT_ID ?? parsed.CLIENT_ID;
+		const clientSecret = parsed.FAKTUROID_CLIENT_SECRET ?? parsed.CLIENT_SECRET;
+		const appName = parsed.FAKTUROID_APP_NAME ?? parsed.APP_NAME ?? "FakturoidMCP";
+		const email = parsed.FAKTUROID_CONTACT_EMAIL ?? parsed.CONTACT_EMAIL ?? "test@example.com";
+
+		if (!apiUrl) {
+			throw new Error("API_URL or FAKTUROID_API_URL is required");
+		}
+		if (!clientId) {
+			throw new Error("CLIENT_ID or FAKTUROID_CLIENT_ID is required");
+		}
+		if (!clientSecret) {
+			throw new Error("CLIENT_SECRET or FAKTUROID_CLIENT_SECRET is required");
+		}
+
+		return {
+			appName,
+			baseURL: apiUrl,
+			clientID: clientId,
+			clientSecret,
+			email,
+		} satisfies Configuration;
+	});
 
 const loadEnvironmentConfiguration = (): Configuration => {
 	dotenv.config({ quiet: true });

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -7,6 +7,7 @@ const DEVELOPMENT_OPTIONS = {
 		level: "debug",
 		options: {
 			colorize: true,
+			destination: 2, // Write to stderr (fd 2) instead of stdout
 		},
 		target: "pino-pretty",
 	},


### PR DESCRIPTION
## Problem

When running as an MCP server in Claude Desktop with NODE_ENV=development,
the server was failing to start with JSON parsing errors. Two issues were identified:

1. **STDIO Logging Conflict**: The pino-pretty logger was writing formatted,
   colorized logs to stdout, which violated the MCP protocol requirement that
   only valid JSON-RPC messages should be written to stdout. This caused
   Claude Desktop to encounter "Unexpected token" and "invalid JSON" errors.

2. **Environment Variable Mismatch**: The code expected unprefixed environment
   variables (API_URL, CLIENT_ID, CLIENT_SECRET) but Claude Desktop config
   used the FAKTUROID_ prefix (FAKTUROID_API_URL, FAKTUROID_CLIENT_ID, etc.),
   causing "Required" validation errors.

## Solution

### Logger Fix (src/utils/logger.ts)
- Added `destination: 2` to pino-pretty options to redirect all logs to stderr
- This ensures MCP JSON-RPC messages remain the only output on stdout
- Debug logs still appear in Claude's MCP log files without protocol interference

### Environment Variables Fix (src/auth/localStrategy.ts)
- Updated EnvironmentConfigurationSchema to accept both prefixed and unprefixed vars
- Added fallback logic: FAKTUROID_* variables take precedence, fall back to unprefixed
- Improved error messages to indicate both accepted variable names
- Supports both .env file usage (unprefixed) and MCP server config (prefixed)

## Impact
- MCP server now starts successfully in Claude Desktop
- Compatible with both naming conventions for maximum flexibility
- No breaking changes for existing .env file configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Functionality verified by @landovsky