### PR TITLE
chore: enable document-skills plugin for the project

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "enabledPlugins": {
+    "cloudflare@claude-plugins-official": true,
+    "document-skills@anthropic-agent-skills": true
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `document-skills@anthropic-agent-skills` to `.claude/settings.json`
- Enables the `mcp-builder` skill (and other document-skills) for all team members working on this repo

## Note
Each team member still needs to install the plugin locally:
```
/plugin install document-skills@anthropic-agent-skills
```