### PR TITLE
chore: enable MCP server development skills

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "enabledPlugins": {
+    "cloudflare@claude-plugins-official": true,
+    "document-skills@anthropic-agent-skills": true
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` with two plugins enabled for the project:
  - **`cloudflare@claude-plugins-official`** — Cloudflare Workers, MCP server deployment, and Agents SDK skills
  - **`document-skills@anthropic-agent-skills`** — MCP builder skill and other document skills

## Setup
Each team member needs to install the plugins locally:
```
/plugin install cloudflare@claude-plugins-official
/plugin install document-skills@anthropic-agent-skills
```