### PR TITLE
feat: Add smart create invoice and expense tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ test_report
 
 .dev.vars
 .wrangler
+.worktrees

--- a/docs/superpowers/plans/2026-04-12-file-upload-staging.md
+++ b/docs/superpowers/plans/2026-04-12-file-upload-staging.md
@@ -1,0 +1,1928 @@
+# File Upload Staging Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a two-phase file upload/download staging mechanism so that AI agents can upload and download files without exhausting the LLM context window.
+
+**Architecture:** An HTTP upload endpoint stores files temporarily in KV (Cloudflare) or in-memory Map (local). MCP tools accept a `file_ref` reference ID instead of raw base64 content. A file resolver service abstracts over multiple source types (file_ref, URL, file path, raw base64). Download tools stage binary in the same storage and return a download URL instead of dumping binary into context.
+
+**Tech Stack:** TypeScript, Zod, Hono (Cloudflare routes), Express (local routes), Cloudflare KV
+
+---
+
+### Task 1: File Staging Storage — Interface and In-Memory Implementation
+
+**Files:**
+- Create: `src/staging/storage.ts`
+- Create: `test/staging/storage.test.ts`
+
+- [ ] **Step 1: Write the failing tests for in-memory staging storage**
+
+```typescript
+// test/staging/storage.test.ts
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { InMemoryFileStaging } from "../../src/staging/storage";
+
+describe("InMemoryFileStaging", () => {
+  let staging: InMemoryFileStaging;
+
+  beforeEach(() => {
+    staging = new InMemoryFileStaging();
+  });
+
+  afterEach(() => {
+    staging.dispose();
+  });
+
+  test("store and retrieve a file", async () => {
+    const content = new Uint8Array([1, 2, 3, 4]);
+    const ref = await staging.store({
+      content: content.buffer as ArrayBuffer,
+      filename: "test.pdf",
+      mimeType: "application/pdf",
+    });
+
+    expect(ref).toMatch(/^ref_/);
+
+    const file = await staging.retrieve(ref);
+    expect(file).not.toBeNull();
+    expect(file!.filename).toBe("test.pdf");
+    expect(file!.mimeType).toBe("application/pdf");
+    expect(new Uint8Array(file!.content)).toEqual(content);
+  });
+
+  test("retrieve returns null for unknown ref", async () => {
+    const file = await staging.retrieve("ref_nonexistent");
+    expect(file).toBeNull();
+  });
+
+  test("retrieve deletes the file after retrieval by default", async () => {
+    const content = new Uint8Array([1, 2, 3]);
+    const ref = await staging.store({
+      content: content.buffer as ArrayBuffer,
+      filename: "test.pdf",
+      mimeType: "application/pdf",
+    });
+
+    await staging.retrieve(ref);
+    const second = await staging.retrieve(ref);
+    expect(second).toBeNull();
+  });
+
+  test("peek retrieves without deleting", async () => {
+    const content = new Uint8Array([1, 2, 3]);
+    const ref = await staging.store({
+      content: content.buffer as ArrayBuffer,
+      filename: "test.pdf",
+      mimeType: "application/pdf",
+    });
+
+    const first = await staging.peek(ref);
+    expect(first).not.toBeNull();
+
+    const second = await staging.peek(ref);
+    expect(second).not.toBeNull();
+  });
+
+  test("expired files are not retrievable", async () => {
+    vi.useFakeTimers();
+
+    const content = new Uint8Array([1, 2, 3]);
+    const ref = await staging.store({
+      content: content.buffer as ArrayBuffer,
+      filename: "test.pdf",
+      mimeType: "application/pdf",
+    });
+
+    // Advance past 5 minute TTL
+    vi.advanceTimersByTime(6 * 60 * 1000);
+
+    const file = await staging.retrieve(ref);
+    expect(file).toBeNull();
+
+    vi.useRealTimers();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test test/staging/storage.test.ts`
+Expected: FAIL — module `../../src/staging/storage` not found
+
+- [ ] **Step 3: Implement the staging storage**
+
+```typescript
+// src/staging/storage.ts
+import { randomUUID } from "node:crypto";
+
+const FILE_STAGING_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const FILE_STAGING_PREFIX = "ref_";
+const CLEANUP_INTERVAL_MS = 60 * 1000; // 1 minute
+
+interface StagedFile {
+  content: ArrayBuffer;
+  filename: string;
+  mimeType: string;
+}
+
+interface StagedFileMetadata {
+  filename: string;
+  mimeType: string;
+  size: number;
+  createdAt: number;
+}
+
+interface FileStaging {
+  store(file: StagedFile): Promise<string>;
+  retrieve(ref: string): Promise<StagedFile | null>;
+  peek(ref: string): Promise<StagedFile | null>;
+}
+
+class InMemoryFileStaging implements FileStaging {
+  private readonly files = new Map<string, StagedFile & { createdAt: number }>();
+  private readonly cleanupTimer: ReturnType<typeof setInterval>;
+
+  constructor() {
+    this.cleanupTimer = setInterval(() => this.cleanup(), CLEANUP_INTERVAL_MS);
+  }
+
+  async store(file: StagedFile): Promise<string> {
+    const ref = `${FILE_STAGING_PREFIX}${randomUUID().replaceAll("-", "")}`;
+    this.files.set(ref, { ...file, createdAt: Date.now() });
+    return ref;
+  }
+
+  async retrieve(ref: string): Promise<StagedFile | null> {
+    const entry = this.files.get(ref);
+    if (entry == null) return null;
+    if (this.isExpired(entry.createdAt)) {
+      this.files.delete(ref);
+      return null;
+    }
+
+    this.files.delete(ref);
+    return { content: entry.content, filename: entry.filename, mimeType: entry.mimeType };
+  }
+
+  async peek(ref: string): Promise<StagedFile | null> {
+    const entry = this.files.get(ref);
+    if (entry == null) return null;
+    if (this.isExpired(entry.createdAt)) {
+      this.files.delete(ref);
+      return null;
+    }
+
+    return { content: entry.content, filename: entry.filename, mimeType: entry.mimeType };
+  }
+
+  dispose(): void {
+    clearInterval(this.cleanupTimer);
+    this.files.clear();
+  }
+
+  private isExpired(createdAt: number): boolean {
+    return Date.now() - createdAt > FILE_STAGING_TTL_MS;
+  }
+
+  private cleanup(): void {
+    for (const [ref, entry] of this.files) {
+      if (this.isExpired(entry.createdAt)) {
+        this.files.delete(ref);
+      }
+    }
+  }
+}
+
+export { InMemoryFileStaging, FILE_STAGING_TTL_MS, FILE_STAGING_PREFIX };
+export type { FileStaging, StagedFile, StagedFileMetadata };
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test test/staging/storage.test.ts`
+Expected: All 5 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/staging/storage.ts test/staging/storage.test.ts
+git commit -m "feat(staging): Add file staging storage interface and in-memory implementation"
+```
+
+---
+
+### Task 2: KV-Backed File Staging for Cloudflare
+
+**Files:**
+- Create: `src/staging/kvStorage.ts`
+- Create: `test/staging/kvStorage.test.ts`
+
+- [ ] **Step 1: Write the failing tests for KV staging storage**
+
+```typescript
+// test/staging/kvStorage.test.ts
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { KVFileStaging } from "../../src/staging/kvStorage";
+
+const createMockKV = () => {
+  const store = new Map<string, { value: string; metadata: unknown }>();
+  return {
+    put: vi.fn(async (key: string, value: string, options?: { expirationTtl?: number; metadata?: unknown }) => {
+      store.set(key, { value, metadata: options?.metadata });
+    }),
+    getWithMetadata: vi.fn(async (key: string) => {
+      const entry = store.get(key);
+      if (entry == null) return { value: null, metadata: null };
+      return { value: entry.value, metadata: entry.metadata };
+    }),
+    delete: vi.fn(async (key: string) => {
+      store.delete(key);
+    }),
+  } as unknown as KVNamespace;
+};
+
+describe("KVFileStaging", () => {
+  let kv: KVNamespace;
+  let staging: KVFileStaging;
+
+  beforeEach(() => {
+    kv = createMockKV();
+    staging = new KVFileStaging(kv);
+  });
+
+  test("store and retrieve a file", async () => {
+    const content = new Uint8Array([1, 2, 3, 4]);
+    const ref = await staging.store({
+      content: content.buffer as ArrayBuffer,
+      filename: "invoice.pdf",
+      mimeType: "application/pdf",
+    });
+
+    expect(ref).toMatch(/^ref_/);
+    expect(kv.put).toHaveBeenCalledOnce();
+
+    const file = await staging.retrieve(ref);
+    expect(file).not.toBeNull();
+    expect(file!.filename).toBe("invoice.pdf");
+    expect(file!.mimeType).toBe("application/pdf");
+    expect(new Uint8Array(file!.content)).toEqual(content);
+
+    // Should delete after retrieval
+    expect(kv.delete).toHaveBeenCalledOnce();
+  });
+
+  test("retrieve returns null for unknown ref", async () => {
+    const file = await staging.retrieve("ref_nonexistent");
+    expect(file).toBeNull();
+  });
+
+  test("peek retrieves without deleting", async () => {
+    const content = new Uint8Array([5, 6, 7]);
+    const ref = await staging.store({
+      content: content.buffer as ArrayBuffer,
+      filename: "photo.png",
+      mimeType: "image/png",
+    });
+
+    const file = await staging.peek(ref);
+    expect(file).not.toBeNull();
+    expect(kv.delete).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test test/staging/kvStorage.test.ts`
+Expected: FAIL — module `../../src/staging/kvStorage` not found
+
+- [ ] **Step 3: Implement the KV staging storage**
+
+```typescript
+// src/staging/kvStorage.ts
+import { randomUUID } from "node:crypto";
+import type { FileStaging, StagedFile, StagedFileMetadata } from "./storage.js";
+import { FILE_STAGING_PREFIX } from "./storage.js";
+
+const FILE_STAGING_TTL_SECONDS = 300; // 5 minutes
+const KV_KEY_PREFIX = "file_staging:";
+
+class KVFileStaging implements FileStaging {
+  private readonly kv: KVNamespace;
+
+  constructor(kv: KVNamespace) {
+    this.kv = kv;
+  }
+
+  async store(file: StagedFile): Promise<string> {
+    const ref = `${FILE_STAGING_PREFIX}${randomUUID().replaceAll("-", "")}`;
+    const base64 = bufferToBase64(file.content);
+
+    const metadata: StagedFileMetadata = {
+      filename: file.filename,
+      mimeType: file.mimeType,
+      size: file.content.byteLength,
+      createdAt: Date.now(),
+    };
+
+    await this.kv.put(`${KV_KEY_PREFIX}${ref}`, base64, {
+      expirationTtl: FILE_STAGING_TTL_SECONDS,
+      metadata,
+    });
+
+    return ref;
+  }
+
+  async retrieve(ref: string): Promise<StagedFile | null> {
+    const file = await this.getFile(ref);
+    if (file != null) {
+      await this.kv.delete(`${KV_KEY_PREFIX}${ref}`);
+    }
+    return file;
+  }
+
+  async peek(ref: string): Promise<StagedFile | null> {
+    return await this.getFile(ref);
+  }
+
+  private async getFile(ref: string): Promise<StagedFile | null> {
+    const { value, metadata } = await this.kv.getWithMetadata<StagedFileMetadata>(`${KV_KEY_PREFIX}${ref}`);
+    if (value == null || metadata == null) return null;
+
+    return {
+      content: base64ToBuffer(value),
+      filename: metadata.filename,
+      mimeType: metadata.mimeType,
+    };
+  }
+}
+
+const bufferToBase64 = (buffer: ArrayBuffer): string => {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+};
+
+const base64ToBuffer = (base64: string): ArrayBuffer => {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer as ArrayBuffer;
+};
+
+export { KVFileStaging };
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test test/staging/kvStorage.test.ts`
+Expected: All 3 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/staging/kvStorage.ts test/staging/kvStorage.test.ts
+git commit -m "feat(staging): Add KV-backed file staging for Cloudflare Workers"
+```
+
+---
+
+### Task 3: File Resolver Service
+
+**Files:**
+- Create: `src/staging/resolver.ts`
+- Create: `test/staging/resolver.test.ts`
+
+- [ ] **Step 1: Write the failing tests for the file resolver**
+
+```typescript
+// test/staging/resolver.test.ts
+import { afterEach, beforeEach, describe, expect, type Mock, test, vi } from "vitest";
+import { resolveFileSource } from "../../src/staging/resolver";
+import { InMemoryFileStaging } from "../../src/staging/storage";
+
+describe("resolveFileSource", () => {
+  let staging: InMemoryFileStaging;
+  let mockedFetch: Mock<typeof global.fetch>;
+
+  beforeEach(() => {
+    staging = new InMemoryFileStaging();
+    global.fetch = vi.fn();
+    mockedFetch = global.fetch as Mock<typeof global.fetch>;
+  });
+
+  afterEach(() => {
+    staging.dispose();
+    mockedFetch.mockReset();
+  });
+
+  test("throws if no source is provided", async () => {
+    await expect(resolveFileSource({}, staging)).rejects.toThrow(
+      "Provide exactly one file source: file_ref, source_url, file_path, or data/attachment",
+    );
+  });
+
+  test("throws if multiple sources are provided", async () => {
+    await expect(
+      resolveFileSource({ file_ref: "ref_abc", source_url: "https://example.com/file.pdf" }, staging),
+    ).rejects.toThrow("Provide exactly one file source");
+  });
+
+  test("resolves file_ref from staging", async () => {
+    const content = new Uint8Array([10, 20, 30]);
+    const ref = await staging.store({
+      content: content.buffer as ArrayBuffer,
+      filename: "staged.pdf",
+      mimeType: "application/pdf",
+    });
+
+    const result = await resolveFileSource({ file_ref: ref }, staging);
+    expect(result.filename).toBe("staged.pdf");
+    expect(result.mimeType).toBe("application/pdf");
+    expect(new Uint8Array(result.content)).toEqual(content);
+  });
+
+  test("throws for expired or unknown file_ref", async () => {
+    await expect(resolveFileSource({ file_ref: "ref_nonexistent" }, staging)).rejects.toThrow(
+      "File reference not found or expired",
+    );
+  });
+
+  test("resolves source_url by fetching", async () => {
+    const content = new Uint8Array([40, 50, 60]);
+    mockedFetch.mockResolvedValue(
+      new Response(content, {
+        headers: { "Content-Type": "application/pdf" },
+      }),
+    );
+
+    const result = await resolveFileSource(
+      { source_url: "https://example.com/invoice.pdf" },
+      staging,
+    );
+
+    expect(result.filename).toBe("invoice.pdf");
+    expect(result.mimeType).toBe("application/pdf");
+    expect(new Uint8Array(result.content)).toEqual(content);
+    expect(mockedFetch).toHaveBeenCalledWith("https://example.com/invoice.pdf");
+  });
+
+  test("resolves source_url with fallback filename", async () => {
+    const content = new Uint8Array([1]);
+    mockedFetch.mockResolvedValue(
+      new Response(content, {
+        headers: { "Content-Type": "image/png" },
+      }),
+    );
+
+    const result = await resolveFileSource(
+      { source_url: "https://example.com/download?id=123" },
+      staging,
+    );
+
+    expect(result.filename).toBe("download");
+    expect(result.mimeType).toBe("image/png");
+  });
+
+  test("resolves raw base64 data (attachment field)", async () => {
+    const original = new Uint8Array([1, 2, 3]);
+    const base64 = btoa(String.fromCharCode(...original));
+
+    const result = await resolveFileSource(
+      { data: base64, filename: "manual.pdf", mimeType: "application/pdf" },
+      staging,
+    );
+
+    expect(result.filename).toBe("manual.pdf");
+    expect(result.mimeType).toBe("application/pdf");
+    expect(new Uint8Array(result.content)).toEqual(original);
+  });
+
+  test("resolves data URI format", async () => {
+    const original = new Uint8Array([4, 5, 6]);
+    const base64 = btoa(String.fromCharCode(...original));
+    const dataUri = `data:image/png;base64,${base64}`;
+
+    const result = await resolveFileSource({ data: dataUri }, staging);
+
+    expect(result.filename).toBe("attachment");
+    expect(result.mimeType).toBe("image/png");
+    expect(new Uint8Array(result.content)).toEqual(original);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test test/staging/resolver.test.ts`
+Expected: FAIL — module `../../src/staging/resolver` not found
+
+- [ ] **Step 3: Implement the file resolver**
+
+```typescript
+// src/staging/resolver.ts
+import type { FileStaging } from "./storage.js";
+
+interface FileSource {
+  file_ref?: string;
+  source_url?: string;
+  file_path?: string;
+  data?: string;
+  filename?: string;
+  mimeType?: string;
+}
+
+interface ResolvedFile {
+  content: ArrayBuffer;
+  filename: string;
+  mimeType: string;
+}
+
+const resolveFileSource = async (source: FileSource, staging: FileStaging): Promise<ResolvedFile> => {
+  const providedSources = [source.file_ref, source.source_url, source.file_path, source.data].filter(
+    (v) => v != null,
+  );
+
+  if (providedSources.length !== 1) {
+    throw new Error("Provide exactly one file source: file_ref, source_url, file_path, or data/attachment");
+  }
+
+  if (source.file_ref != null) {
+    return await resolveFromStaging(source.file_ref, staging);
+  }
+
+  if (source.source_url != null) {
+    return await resolveFromUrl(source.source_url);
+  }
+
+  if (source.file_path != null) {
+    return await resolveFromFilePath(source.file_path);
+  }
+
+  return resolveFromData(source.data!, source.filename, source.mimeType);
+};
+
+const resolveFromStaging = async (ref: string, staging: FileStaging): Promise<ResolvedFile> => {
+  const file = await staging.retrieve(ref);
+  if (file == null) {
+    throw new Error("File reference not found or expired. Upload the file again at /upload");
+  }
+  return file;
+};
+
+const resolveFromUrl = async (url: string): Promise<ResolvedFile> => {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch file from URL: HTTP ${response.status}`);
+  }
+
+  const content = await response.arrayBuffer();
+  const mimeType = response.headers.get("Content-Type") ?? "application/octet-stream";
+  const filename = extractFilenameFromUrl(url);
+
+  return { content, filename, mimeType };
+};
+
+const resolveFromFilePath = async (filePath: string): Promise<ResolvedFile> => {
+  try {
+    const fs = await import("node:fs/promises");
+    const path = await import("node:path");
+
+    const buffer = await fs.readFile(filePath);
+    const filename = path.basename(filePath);
+    const mimeType = inferMimeType(filename);
+
+    return { content: buffer.buffer as ArrayBuffer, filename, mimeType };
+  } catch (error) {
+    if (error instanceof TypeError || (error as NodeJS.ErrnoException).code === "MODULE_NOT_FOUND") {
+      throw new Error("file_path is not supported on the hosted deployment. Use the /upload page to get a file_ref instead.");
+    }
+    throw new Error(`Failed to read file: ${(error as Error).message}`);
+  }
+};
+
+const resolveFromData = (data: string, filename?: string, mimeType?: string): ResolvedFile => {
+  const dataUriMatch = data.match(/^data:([^;]+);base64,(.+)$/);
+  if (dataUriMatch != null) {
+    const parsedMime = dataUriMatch[1];
+    const base64Content = dataUriMatch[2];
+    return {
+      content: base64ToBuffer(base64Content),
+      filename: filename ?? "attachment",
+      mimeType: mimeType ?? parsedMime,
+    };
+  }
+
+  // Raw base64
+  return {
+    content: base64ToBuffer(data),
+    filename: filename ?? "attachment",
+    mimeType: mimeType ?? "application/octet-stream",
+  };
+};
+
+const extractFilenameFromUrl = (url: string): string => {
+  try {
+    const pathname = new URL(url).pathname;
+    const lastSegment = pathname.split("/").pop() ?? "download";
+    return lastSegment || "download";
+  } catch {
+    return "download";
+  }
+};
+
+const inferMimeType = (filename: string): string => {
+  const ext = filename.split(".").pop()?.toLowerCase();
+  const mimeTypes: Record<string, string> = {
+    pdf: "application/pdf",
+    png: "image/png",
+    jpg: "image/jpeg",
+    jpeg: "image/jpeg",
+    gif: "image/gif",
+    xml: "application/xml",
+  };
+  return mimeTypes[ext ?? ""] ?? "application/octet-stream";
+};
+
+const base64ToBuffer = (base64: string): ArrayBuffer => {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer as ArrayBuffer;
+};
+
+const bufferToBase64 = (buffer: ArrayBuffer): string => {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+};
+
+const bufferToDataUri = (buffer: ArrayBuffer, mimeType: string): string => {
+  return `data:${mimeType};base64,${bufferToBase64(buffer)}`;
+};
+
+export { resolveFileSource, bufferToBase64, bufferToDataUri };
+export type { FileSource, ResolvedFile };
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test test/staging/resolver.test.ts`
+Expected: All 8 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/staging/resolver.ts test/staging/resolver.test.ts
+git commit -m "feat(staging): Add file resolver service supporting ref, URL, path, and base64 sources"
+```
+
+---
+
+### Task 4: Upload Page HTML Template
+
+**Files:**
+- Create: `src/staging/upload-page.ts`
+
+- [ ] **Step 1: Create the upload page template**
+
+This is a static HTML template — no test needed, it will be verified through the smoke test in Task 13.
+
+```typescript
+// src/staging/upload-page.ts
+const uploadPageHtml = (baseUrl: string): string => `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fakturoid MCP - File Upload</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 600px; margin: 40px auto; padding: 0 20px; color: #333; }
+    h1 { font-size: 1.4rem; margin-bottom: 8px; }
+    p.subtitle { color: #666; margin-bottom: 24px; font-size: 0.9rem; }
+    .drop-zone { border: 2px dashed #ccc; border-radius: 8px; padding: 48px 24px; text-align: center; cursor: pointer; transition: border-color 0.2s, background 0.2s; }
+    .drop-zone:hover, .drop-zone.dragover { border-color: #4a90d9; background: #f0f6ff; }
+    .drop-zone input { display: none; }
+    .drop-zone p { color: #666; margin-bottom: 8px; }
+    .drop-zone .browse { color: #4a90d9; text-decoration: underline; cursor: pointer; }
+    .result { margin-top: 24px; padding: 16px; border-radius: 8px; display: none; }
+    .result.success { background: #e8f5e9; border: 1px solid #a5d6a7; display: block; }
+    .result.error { background: #fce4ec; border: 1px solid #ef9a9a; display: block; }
+    .ref-id { font-family: monospace; font-size: 1.1rem; font-weight: bold; user-select: all; }
+    .copy-btn { margin-top: 8px; padding: 6px 16px; background: #4a90d9; color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 0.85rem; }
+    .copy-btn:hover { background: #3a7bc8; }
+    .info { margin-top: 8px; font-size: 0.8rem; color: #666; }
+    .spinner { display: none; margin-top: 16px; text-align: center; color: #666; }
+  </style>
+</head>
+<body>
+  <h1>Fakturoid MCP - File Upload</h1>
+  <p class="subtitle">Upload a file to get a reference ID. Give the reference ID to your AI assistant.</p>
+
+  <div class="drop-zone" id="dropZone">
+    <p>Drag and drop a file here</p>
+    <p>or <span class="browse" id="browseBtn">browse files</span></p>
+    <p style="margin-top: 12px; font-size: 0.8rem; color: #999;">PDF, PNG, JPEG, GIF, XML - max 10MB</p>
+    <input type="file" id="fileInput" accept=".pdf,.png,.jpg,.jpeg,.gif,.xml">
+  </div>
+
+  <div class="spinner" id="spinner">Uploading...</div>
+
+  <div class="result" id="result">
+    <p id="resultMessage"></p>
+    <p class="ref-id" id="refId"></p>
+    <button class="copy-btn" id="copyBtn" style="display:none;">Copy reference ID</button>
+    <p class="info" id="fileInfo"></p>
+  </div>
+
+  <script>
+    const dropZone = document.getElementById("dropZone");
+    const fileInput = document.getElementById("fileInput");
+    const browseBtn = document.getElementById("browseBtn");
+    const spinner = document.getElementById("spinner");
+    const result = document.getElementById("result");
+    const resultMessage = document.getElementById("resultMessage");
+    const refIdEl = document.getElementById("refId");
+    const copyBtn = document.getElementById("copyBtn");
+    const fileInfo = document.getElementById("fileInfo");
+
+    browseBtn.addEventListener("click", () => fileInput.click());
+    fileInput.addEventListener("change", (e) => { if (e.target.files[0]) uploadFile(e.target.files[0]); });
+
+    dropZone.addEventListener("dragover", (e) => { e.preventDefault(); dropZone.classList.add("dragover"); });
+    dropZone.addEventListener("dragleave", () => dropZone.classList.remove("dragover"));
+    dropZone.addEventListener("drop", (e) => {
+      e.preventDefault();
+      dropZone.classList.remove("dragover");
+      if (e.dataTransfer.files[0]) uploadFile(e.dataTransfer.files[0]);
+    });
+
+    async function uploadFile(file) {
+      spinner.style.display = "block";
+      result.className = "result";
+      resultMessage.textContent = "";
+      refIdEl.textContent = "";
+      copyBtn.style.display = "none";
+      fileInfo.textContent = "";
+
+      try {
+        const formData = new FormData();
+        formData.append("file", file);
+
+        const response = await fetch("${baseUrl}/upload", { method: "POST", body: formData });
+        const data = await response.json();
+
+        if (!response.ok) {
+          throw new Error(data.error || "Upload failed");
+        }
+
+        resultMessage.textContent = "File uploaded successfully!";
+        refIdEl.textContent = data.file_ref;
+        copyBtn.style.display = "inline-block";
+        copyBtn.onclick = () => navigator.clipboard.writeText(data.file_ref);
+        fileInfo.textContent = data.filename + " (" + (data.size / 1024).toFixed(1) + " KB) - expires in " + data.expires_in_seconds + "s";
+        result.className = "result success";
+      } catch (err) {
+        resultMessage.textContent = "Error: " + err.message;
+        result.className = "result error";
+      } finally {
+        spinner.style.display = "none";
+        fileInput.value = "";
+      }
+    }
+  </script>
+</body>
+</html>`;
+
+export { uploadPageHtml };
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/staging/upload-page.ts
+git commit -m "feat(staging): Add upload page HTML template"
+```
+
+---
+
+### Task 5: Upload and Download Route Handlers
+
+**Files:**
+- Create: `src/staging/routes.ts`
+- Create: `test/staging/routes.test.ts`
+
+- [ ] **Step 1: Write failing tests for the route handler logic**
+
+```typescript
+// test/staging/routes.test.ts
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { handleFileUpload, handleFileDownload } from "../../src/staging/routes";
+import { InMemoryFileStaging } from "../../src/staging/storage";
+
+describe("handleFileUpload", () => {
+  let staging: InMemoryFileStaging;
+
+  beforeEach(() => {
+    staging = new InMemoryFileStaging();
+  });
+
+  afterEach(() => {
+    staging.dispose();
+  });
+
+  test("stores a file and returns ref metadata", async () => {
+    const content = new Uint8Array([1, 2, 3, 4, 5]);
+    const result = await handleFileUpload(staging, {
+      content: content.buffer as ArrayBuffer,
+      filename: "invoice.pdf",
+      mimeType: "application/pdf",
+    });
+
+    expect(result.file_ref).toMatch(/^ref_/);
+    expect(result.filename).toBe("invoice.pdf");
+    expect(result.size).toBe(5);
+    expect(result.mime_type).toBe("application/pdf");
+    expect(result.expires_in_seconds).toBe(300);
+  });
+
+  test("rejects files over 10MB", async () => {
+    const content = new Uint8Array(11 * 1024 * 1024); // 11MB
+    await expect(
+      handleFileUpload(staging, {
+        content: content.buffer as ArrayBuffer,
+        filename: "huge.pdf",
+        mimeType: "application/pdf",
+      }),
+    ).rejects.toThrow("File exceeds maximum size of 10MB");
+  });
+
+  test("rejects unsupported MIME types", async () => {
+    const content = new Uint8Array([1]);
+    await expect(
+      handleFileUpload(staging, {
+        content: content.buffer as ArrayBuffer,
+        filename: "script.js",
+        mimeType: "application/javascript",
+      }),
+    ).rejects.toThrow("Unsupported file type");
+  });
+});
+
+describe("handleFileDownload", () => {
+  let staging: InMemoryFileStaging;
+
+  beforeEach(() => {
+    staging = new InMemoryFileStaging();
+  });
+
+  afterEach(() => {
+    staging.dispose();
+  });
+
+  test("returns staged file for valid ref", async () => {
+    const content = new Uint8Array([10, 20, 30]);
+    const ref = await staging.store({
+      content: content.buffer as ArrayBuffer,
+      filename: "report.pdf",
+      mimeType: "application/pdf",
+    });
+
+    const result = await handleFileDownload(staging, ref);
+    expect(result).not.toBeNull();
+    expect(result!.filename).toBe("report.pdf");
+    expect(result!.mimeType).toBe("application/pdf");
+    expect(new Uint8Array(result!.content)).toEqual(content);
+  });
+
+  test("returns null for unknown ref", async () => {
+    const result = await handleFileDownload(staging, "ref_unknown");
+    expect(result).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test test/staging/routes.test.ts`
+Expected: FAIL — module `../../src/staging/routes` not found
+
+- [ ] **Step 3: Implement the route handlers**
+
+```typescript
+// src/staging/routes.ts
+import type { FileStaging, StagedFile } from "./storage.js";
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+
+const ALLOWED_MIME_TYPES = new Set([
+  "application/pdf",
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "text/xml",
+  "application/xml",
+]);
+
+interface UploadInput {
+  content: ArrayBuffer;
+  filename: string;
+  mimeType: string;
+}
+
+interface UploadResult {
+  file_ref: string;
+  filename: string;
+  size: number;
+  mime_type: string;
+  expires_in_seconds: number;
+}
+
+const handleFileUpload = async (staging: FileStaging, input: UploadInput): Promise<UploadResult> => {
+  if (input.content.byteLength > MAX_FILE_SIZE) {
+    throw new Error("File exceeds maximum size of 10MB");
+  }
+
+  if (!ALLOWED_MIME_TYPES.has(input.mimeType)) {
+    throw new Error(`Unsupported file type: ${input.mimeType}. Allowed: PDF, PNG, JPEG, GIF, XML`);
+  }
+
+  const ref = await staging.store({
+    content: input.content,
+    filename: input.filename,
+    mimeType: input.mimeType,
+  });
+
+  return {
+    file_ref: ref,
+    filename: input.filename,
+    size: input.content.byteLength,
+    mime_type: input.mimeType,
+    expires_in_seconds: 300,
+  };
+};
+
+const handleFileDownload = async (staging: FileStaging, ref: string): Promise<StagedFile | null> => {
+  return await staging.peek(ref);
+};
+
+export { handleFileUpload, handleFileDownload };
+export type { UploadInput, UploadResult };
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test test/staging/routes.test.ts`
+Expected: All 5 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/staging/routes.ts test/staging/routes.test.ts
+git commit -m "feat(staging): Add upload and download route handler logic"
+```
+
+---
+
+### Task 6: Wire Staging Into Server and Tool Infrastructure
+
+This task threads the `FileStaging` instance through the server -> tools pipeline so tools can access it.
+
+**Files:**
+- Modify: `src/fakturoid/tool/common.ts`
+- Modify: `src/fakturoid/tools.ts`
+- Modify: `src/server.ts`
+
+- [ ] **Step 1: Update `createTool` to accept staging storage**
+
+Replace the full contents of `src/fakturoid/tool/common.ts`:
+
+```typescript
+// src/fakturoid/tool/common.ts
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { z } from "zod/v3";
+import type { AuthenticationStrategy } from "../../auth/strategy.js";
+import type { FakturoidClient } from "../client.js";
+import type { FileStaging } from "../../staging/storage.js";
+import { logger } from "../../utils/logger.js";
+
+type ServerToolCreator<
+	Configuration extends object = object,
+	Strategy extends AuthenticationStrategy<Configuration> = AuthenticationStrategy<Configuration>,
+> = (server: McpServer, client: FakturoidClient<Configuration, Strategy>, staging: FileStaging) => void;
+
+const createTool = <
+	InputSchema extends z.ZodRawShape | undefined = undefined,
+	Configuration extends object = object,
+	Strategy extends AuthenticationStrategy<Configuration> = AuthenticationStrategy<Configuration>,
+>(
+	name: string,
+	title: string,
+	description: string,
+	implementation: (
+		client: FakturoidClient<Configuration, Strategy>,
+		input: InputSchema extends z.ZodRawShape ? z.objectOutputType<InputSchema, z.ZodTypeAny> : undefined,
+		staging: FileStaging,
+	) => CallToolResult | Promise<CallToolResult>,
+	inputSchema?: InputSchema,
+): ServerToolCreator<Configuration, Strategy> => {
+	return (server, client, staging) => {
+		try {
+			if (inputSchema == null) {
+				return server.registerTool(name, { title: title, description: description }, () =>
+					implementation(
+						client,
+						undefined as InputSchema extends z.ZodRawShape ? z.objectOutputType<InputSchema, z.ZodTypeAny> : undefined,
+						staging,
+					),
+				);
+			}
+
+			// Yeah, we don't care for that, Typescript.
+			// @ts-expect-error "Type instantiation is excessively deep and possibly infinite"
+			return server.registerTool(name, { title: title, description: description, inputSchema: inputSchema }, (input) =>
+				implementation(
+					client,
+					input as InputSchema extends z.ZodRawShape ? z.objectOutputType<InputSchema, z.ZodTypeAny> : undefined,
+					staging,
+				),
+			);
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : String(error);
+
+			logger.error("Failed to execute a tool.");
+			logger.error(message);
+
+			return {
+				content: [{ isError: true, text: `Error: ${message}`, type: "text" }],
+			};
+		}
+	};
+};
+
+export { createTool };
+export type { ServerToolCreator };
+```
+
+- [ ] **Step 2: Update `registerFakturoidTools` to accept and pass staging**
+
+Edit `src/fakturoid/tools.ts` — add the import and update the function signature:
+
+Add import:
+```typescript
+import type { FileStaging } from "../staging/storage.js";
+```
+
+Change the function signature and tool registration loop:
+```typescript
+const registerFakturoidTools = <
+	Configuration extends object = object,
+	Strategy extends AuthenticationStrategy<Configuration> = AuthenticationStrategy<Configuration>,
+>(
+	server: McpServer,
+	client: FakturoidClient<Configuration, Strategy>,
+	staging: FileStaging,
+): void => {
+	// ... same tools array ...
+
+	for (const registerTool of tools) {
+		registerTool(server, client, staging);
+	}
+};
+```
+
+- [ ] **Step 3: Update `createServer` to accept and pass staging**
+
+Edit `src/server.ts` — add the import and update the function:
+
+Add import:
+```typescript
+import type { FileStaging } from "./staging/storage.js";
+```
+
+Change the function signature:
+```typescript
+const createServer = async <Configuration extends object, Strategy extends AuthenticationStrategy<Configuration>>(
+	strategy: Strategy,
+	staging: FileStaging,
+): Promise<McpServer> => {
+```
+
+Update the `registerFakturoidTools` call:
+```typescript
+	registerFakturoidTools(server, fakturoidClient, staging);
+```
+
+- [ ] **Step 4: Run type check to verify**
+
+Run: `pnpm run types`
+Expected: No type errors (existing tools will accept the extra `staging` parameter without changes since it's just an additional callback argument)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/fakturoid/tool/common.ts src/fakturoid/tools.ts src/server.ts
+git commit -m "refactor(tools): Thread FileStaging through server and tool infrastructure"
+```
+
+---
+
+### Task 7: Update Upload Tools — Inbox File
+
+**Files:**
+- Modify: `src/fakturoid/model/inboxFile.ts`
+- Modify: `src/fakturoid/tool/inboxFile.ts`
+
+- [ ] **Step 1: Add tool-level schema to the inbox file model**
+
+Edit `src/fakturoid/model/inboxFile.ts`. Add after the existing `CreateInboxFileSchema`:
+
+```typescript
+const CreateInboxFileToolSchema = z.object({
+	/** Reference ID from the /upload page */
+	file_ref: z.string().optional(),
+	/** URL to fetch the file from */
+	source_url: z.string().optional(),
+	/** Local file path (only works when server runs locally) */
+	file_path: z.string().optional(),
+	/** File content as Base64 encoded string (fallback - prefer file_ref or source_url to avoid context exhaustion) */
+	attachment: z.string().optional(),
+	/** File name (with extension) */
+	filename: z.string().optional(),
+	/** The file will be sent to OCR */
+	send_to_ocr: z.boolean().optional(),
+});
+
+type CreateInboxFileTool = z.infer<typeof CreateInboxFileToolSchema>;
+```
+
+Add `CreateInboxFileToolSchema` and `CreateInboxFileTool` to the exports.
+
+- [ ] **Step 2: Update the inbox file tool to use the file resolver**
+
+Edit `src/fakturoid/tool/inboxFile.ts`. Update imports and replace the `createInboxFile` tool:
+
+Add imports:
+```typescript
+import { resolveFileSource, bufferToBase64 } from "../../staging/resolver.js";
+import { CreateInboxFileToolSchema } from "../model/inboxFile.js";
+```
+
+Replace the `createInboxFile` tool definition:
+```typescript
+const createInboxFile = createTool(
+	"fakturoid_create_inbox_file",
+	"Create Inbox File",
+	"Upload a new file to the inbox for processing. Provide exactly one file source: file_ref (from /upload page - preferred), source_url, file_path (local server only), or attachment (base64 - avoid, exhausts context).",
+	async (client, input, staging) => {
+		const resolved = await resolveFileSource(
+			{
+				file_ref: input.file_ref,
+				source_url: input.source_url,
+				file_path: input.file_path,
+				data: input.attachment,
+				filename: input.filename,
+			},
+			staging,
+		);
+
+		const inboxFile = await client.createInboxFile({
+			attachment: bufferToBase64(resolved.content),
+			filename: input.filename ?? resolved.filename,
+			send_to_ocr: input.send_to_ocr,
+		});
+
+		return {
+			content: [{ text: JSON.stringify(inboxFile, null, 2), type: "text" }],
+		};
+	},
+	CreateInboxFileToolSchema.shape,
+);
+```
+
+Remove the old import of `CreateInboxFileSchema` (it is no longer used by the tool).
+
+- [ ] **Step 3: Run lint and type check**
+
+Run: `pnpm run types && pnpm run lint`
+Expected: No errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/fakturoid/model/inboxFile.ts src/fakturoid/tool/inboxFile.ts
+git commit -m "feat(tools): Update inbox file upload to support file_ref, URL, and path sources"
+```
+
+---
+
+### Task 8: Update Upload Tools — Invoice and Expense Attachments
+
+**Files:**
+- Modify: `src/fakturoid/model/common.ts`
+- Modify: `src/staging/resolver.ts`
+- Modify: `src/fakturoid/tool/invoice.ts`
+- Modify: `src/fakturoid/tool/expense.ts`
+
+- [ ] **Step 1: Add tool-level attachment schema to common.ts**
+
+Edit `src/fakturoid/model/common.ts`. Add after the existing `CreateAttachmentSchema`:
+
+```typescript
+const CreateAttachmentToolSchema = z.object({
+	/** Reference ID from the /upload page */
+	file_ref: z.string().optional(),
+	/** URL to fetch the file from */
+	source_url: z.string().optional(),
+	/** Local file path (only works when server runs locally) */
+	file_path: z.string().optional(),
+	/** Attachment contents in the form of a Data URI (fallback - prefer file_ref or source_url) */
+	data_url: z.string().optional(),
+	/** Attachment file name */
+	filename: z.string().optional(),
+});
+
+type CreateAttachmentTool = z.infer<typeof CreateAttachmentToolSchema>;
+```
+
+Add `CreateAttachmentToolSchema` and `CreateAttachmentTool` to the exports.
+
+- [ ] **Step 2: Add `resolveAttachments` helper to the resolver**
+
+Edit `src/staging/resolver.ts`. Add the following types and function:
+
+```typescript
+import type { CreateAttachment } from "../fakturoid/model/common.js";
+
+interface AttachmentToolInput {
+  file_ref?: string;
+  source_url?: string;
+  file_path?: string;
+  data_url?: string;
+  filename?: string;
+}
+
+const resolveAttachments = async (
+  attachments: AttachmentToolInput[] | undefined,
+  staging: FileStaging,
+): Promise<CreateAttachment[] | undefined> => {
+  if (attachments == null || attachments.length === 0) return undefined;
+
+  const resolved: CreateAttachment[] = [];
+  for (const att of attachments) {
+    const file = await resolveFileSource(
+      {
+        file_ref: att.file_ref,
+        source_url: att.source_url,
+        file_path: att.file_path,
+        data: att.data_url,
+        filename: att.filename,
+      },
+      staging,
+    );
+
+    resolved.push({
+      data_url: bufferToDataUri(file.content, file.mimeType),
+      filename: att.filename ?? file.filename,
+    });
+  }
+
+  return resolved;
+};
+```
+
+Add `resolveAttachments` and `AttachmentToolInput` to the exports.
+
+- [ ] **Step 3: Update the invoice create tool**
+
+Edit `src/fakturoid/tool/invoice.ts`. Add imports and update the `createInvoice` tool:
+
+Add imports:
+```typescript
+import { resolveAttachments } from "../../staging/resolver.js";
+import { CreateAttachmentToolSchema } from "../model/common.js";
+```
+
+Replace the `createInvoice` tool definition:
+```typescript
+const createInvoice = createTool(
+	"fakturoid_create_invoice",
+	"Create Invoice",
+	"Create a new invoice with the provided invoice data. subject_id is necessary for the invoice to be created. For attachments, provide file_ref (from /upload page - preferred), source_url, file_path, or data_url.",
+	async (client, invoiceData, staging) => {
+		const resolvedAttachments = await resolveAttachments(invoiceData.attachments, staging);
+
+		const invoice = await client.createInvoice({
+			...invoiceData,
+			attachments: resolvedAttachments,
+		});
+
+		return {
+			content: [{ text: JSON.stringify(invoice, null, 2), type: "text" }],
+		};
+	},
+	{
+		...CreateInvoiceSchema.shape,
+		attachments: z.array(CreateAttachmentToolSchema).optional(),
+	},
+);
+```
+
+- [ ] **Step 4: Update the expense create tool with the same pattern**
+
+Edit `src/fakturoid/tool/expense.ts`. Add imports and update the `createExpense` tool:
+
+Add imports:
+```typescript
+import { resolveAttachments } from "../../staging/resolver.js";
+import { CreateAttachmentToolSchema } from "../model/common.js";
+```
+
+Replace the `createExpense` tool definition:
+```typescript
+const createExpense = createTool(
+	"fakturoid_create_expense",
+	"Create Expense",
+	"Create a new expense with the provided expense data. For attachments, provide file_ref (from /upload page - preferred), source_url, file_path, or data_url.",
+	async (client, expenseData, staging) => {
+		const resolvedAttachments = await resolveAttachments(expenseData.attachments, staging);
+
+		const expense = await client.createExpense({
+			...expenseData,
+			attachments: resolvedAttachments,
+		});
+
+		return {
+			content: [{ text: JSON.stringify(expense, null, 2), type: "text" }],
+		};
+	},
+	{
+		...CreateExpenseSchema.shape,
+		attachments: z.array(CreateAttachmentToolSchema).optional(),
+	},
+);
+```
+
+- [ ] **Step 5: Run type check and lint**
+
+Run: `pnpm run types && pnpm run lint`
+Expected: No errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/fakturoid/model/common.ts src/staging/resolver.ts src/fakturoid/tool/invoice.ts src/fakturoid/tool/expense.ts
+git commit -m "feat(tools): Update invoice and expense attachments to support file staging sources"
+```
+
+---
+
+### Task 9: Improve Download Tools
+
+**Files:**
+- Modify: `src/fakturoid/tool/invoice.ts`
+- Modify: `src/fakturoid/tool/expense.ts`
+- Modify: `src/fakturoid/tool/inboxFile.ts`
+
+- [ ] **Step 1: Update `downloadInvoicePDF` to stage the binary**
+
+Edit `src/fakturoid/tool/invoice.ts`. Replace the `downloadInvoicePDF` tool:
+
+```typescript
+const downloadInvoicePDF = createTool(
+	"fakturoid_download_invoice_pdf",
+	"Download Invoice PDF",
+	"Download the PDF version of an invoice by its ID. Returns a file reference that can be opened via /download/:ref",
+	async (client, { id }, staging) => {
+		const pdf = await client.downloadInvoicePDF(id);
+
+		if (pdf instanceof Blob) {
+			const buffer = await pdf.arrayBuffer();
+			const ref = await staging.store({
+				content: buffer,
+				filename: `invoice-${id}.pdf`,
+				mimeType: "application/pdf",
+			});
+			const sizeKB = (buffer.byteLength / 1024).toFixed(1);
+
+			return {
+				content: [
+					{
+						text: `Invoice PDF downloaded successfully. File ref: ${ref} (expires in 5 minutes). Size: ${sizeKB} KB. Open in browser: /download/${ref}`,
+						type: "text" as const,
+					},
+				],
+			};
+		}
+
+		return {
+			content: [{ text: `Error downloading invoice PDF: ${String(pdf)}`, type: "text" as const }],
+			isError: true,
+		};
+	},
+	{
+		id: z.number(),
+	},
+);
+```
+
+- [ ] **Step 2: Update `downloadInvoiceAttachment` to stage the binary**
+
+Edit `src/fakturoid/tool/invoice.ts`. Replace the `downloadInvoiceAttachment` tool:
+
+```typescript
+const downloadInvoiceAttachment = createTool(
+	"fakturoid_download_invoice_attachment",
+	"Download Invoice Attachment",
+	"Download a specific attachment from an invoice. Returns a file reference that can be opened via /download/:ref",
+	async (client, { invoiceId, attachmentId }, staging) => {
+		const attachment = await client.downloadInvoiceAttachment(invoiceId, attachmentId);
+
+		if (attachment instanceof Blob) {
+			const buffer = await attachment.arrayBuffer();
+			const mimeType = attachment.type || "application/octet-stream";
+			const ref = await staging.store({
+				content: buffer,
+				filename: `invoice-${invoiceId}-attachment-${attachmentId}`,
+				mimeType,
+			});
+			const sizeKB = (buffer.byteLength / 1024).toFixed(1);
+
+			return {
+				content: [
+					{
+						text: `Attachment downloaded successfully. File ref: ${ref} (expires in 5 minutes). Size: ${sizeKB} KB. Open in browser: /download/${ref}`,
+						type: "text" as const,
+					},
+				],
+			};
+		}
+
+		return {
+			content: [{ text: `Error downloading attachment: ${String(attachment)}`, type: "text" as const }],
+			isError: true,
+		};
+	},
+	{
+		attachmentId: z.number(),
+		invoiceId: z.number(),
+	},
+);
+```
+
+- [ ] **Step 3: Update `downloadExpenseAttachment` with the same pattern**
+
+Edit `src/fakturoid/tool/expense.ts`. Replace the `downloadExpenseAttachment` tool:
+
+```typescript
+const downloadExpenseAttachment = createTool(
+	"fakturoid_download_expense_attachment",
+	"Download Expense Attachment",
+	"Download a specific attachment from an expense. Returns a file reference that can be opened via /download/:ref",
+	async (client, { expenseId, attachmentId }, staging) => {
+		const attachment = await client.downloadExpenseAttachment(expenseId, attachmentId);
+
+		if (attachment instanceof Blob) {
+			const buffer = await attachment.arrayBuffer();
+			const mimeType = attachment.type || "application/octet-stream";
+			const ref = await staging.store({
+				content: buffer,
+				filename: `expense-${expenseId}-attachment-${attachmentId}`,
+				mimeType,
+			});
+			const sizeKB = (buffer.byteLength / 1024).toFixed(1);
+
+			return {
+				content: [
+					{
+						text: `Attachment downloaded successfully. File ref: ${ref} (expires in 5 minutes). Size: ${sizeKB} KB. Open in browser: /download/${ref}`,
+						type: "text" as const,
+					},
+				],
+			};
+		}
+
+		return {
+			content: [{ text: `Error downloading attachment: ${String(attachment)}`, type: "text" as const }],
+			isError: true,
+		};
+	},
+	{
+		attachmentId: z.number(),
+		expenseId: z.number(),
+	},
+);
+```
+
+- [ ] **Step 4: Update `downloadInboxFile` to stage the binary**
+
+Edit `src/fakturoid/tool/inboxFile.ts`. Replace the `downloadInboxFile` tool:
+
+```typescript
+const downloadInboxFile = createTool(
+	"fakturoid_download_inbox_file",
+	"Download Inbox File",
+	"Download a file from the inbox by its ID. Returns a file reference that can be opened via /download/:ref",
+	async (client, { id }, staging) => {
+		const file = await client.downloadInboxFile(id);
+
+		if (file instanceof Blob) {
+			const buffer = await file.arrayBuffer();
+			const mimeType = file.type || "application/octet-stream";
+			const ref = await staging.store({
+				content: buffer,
+				filename: `inbox-file-${id}`,
+				mimeType,
+			});
+			const sizeKB = (buffer.byteLength / 1024).toFixed(1);
+
+			return {
+				content: [
+					{
+						text: `Inbox file downloaded successfully. File ref: ${ref} (expires in 5 minutes). Size: ${sizeKB} KB. Open in browser: /download/${ref}`,
+						type: "text" as const,
+					},
+				],
+			};
+		}
+
+		return {
+			content: [{ text: `Error downloading inbox file: ${String(file)}`, type: "text" as const }],
+			isError: true,
+		};
+	},
+	{
+		id: z.number(),
+	},
+);
+```
+
+- [ ] **Step 5: Run type check and lint**
+
+Run: `pnpm run types && pnpm run lint`
+Expected: No errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/fakturoid/tool/invoice.ts src/fakturoid/tool/expense.ts src/fakturoid/tool/inboxFile.ts
+git commit -m "feat(tools): Download tools now stage binary and return file refs instead of dumping to context"
+```
+
+---
+
+### Task 10: Wire Upload/Download Routes Into Local Server
+
+**Files:**
+- Modify: `src/main.ts`
+
+- [ ] **Step 1: Add staging, upload, and download routes to all transport modes**
+
+Edit `src/main.ts`. Add imports at the top:
+
+```typescript
+import { InMemoryFileStaging } from "./staging/storage.js";
+import { handleFileUpload, handleFileDownload } from "./staging/routes.js";
+import { uploadPageHtml } from "./staging/upload-page.js";
+```
+
+Update `startSTDIO` to pass a staging instance:
+
+```typescript
+const startSTDIO = async (strategy: AuthenticationStrategy): Promise<void> => {
+	logger.info("Starting the server in STDIO transport mode.");
+
+	const transport = new StdioServerTransport();
+	const staging = new InMemoryFileStaging();
+	const server = await createServer(strategy, staging);
+
+	await server.connect(transport);
+};
+```
+
+Update `startSSE` to pass a staging instance:
+
+```typescript
+const startSSE = async (strategy: AuthenticationStrategy, port: number): Promise<void> => {
+	// ... existing code up to server creation ...
+	const staging = new InMemoryFileStaging();
+	const server = await createServer(strategy, staging);
+	// ... rest unchanged ...
+};
+```
+
+Update `startHTTP` to create staging and add routes. Add upload/download routes BEFORE the MCP route, and pass staging to `createServer`:
+
+```typescript
+const startHTTP = (strategy: AuthenticationStrategy, port: number): void => {
+	logger.info(`Starting the server in Streamable HTTP transport mode on port ${port}.`);
+
+	const app = express();
+	app.use(express.json());
+	app.disable("x-powered-by");
+
+	const staging = new InMemoryFileStaging();
+	const transports: HttpTransports = {};
+
+	// Upload page
+	app.get("/upload", (_request: Request, response: Response) => {
+		response.setHeader("Content-Type", "text/html");
+		response.send(uploadPageHtml(`http://localhost:${port}`));
+	});
+
+	// Upload endpoint
+	app.post("/upload", async (request: Request, response: Response) => {
+		try {
+			const contentType = request.get("content-type") ?? "";
+			if (!contentType.includes("multipart/form-data")) {
+				response.status(400).json({ error: "Expected multipart/form-data" });
+				return;
+			}
+
+			const rawBody = await new Promise<Buffer>((resolve) => {
+				const chunks: Buffer[] = [];
+				request.on("data", (chunk: Buffer) => chunks.push(chunk));
+				request.on("end", () => resolve(Buffer.concat(chunks)));
+			});
+
+			const webRequest = new globalThis.Request("http://localhost/upload", {
+				method: "POST",
+				headers: { "Content-Type": contentType },
+				body: rawBody,
+			});
+
+			const formData = await webRequest.formData();
+			const file = formData.get("file");
+			if (!(file instanceof File)) {
+				response.status(400).json({ error: "No file provided" });
+				return;
+			}
+
+			const result = await handleFileUpload(staging, {
+				content: await file.arrayBuffer(),
+				filename: file.name,
+				mimeType: file.type || "application/octet-stream",
+			});
+
+			response.json(result);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			response.status(400).json({ error: message });
+		}
+	});
+
+	// Download endpoint
+	app.get("/download/:ref", async (request: Request, response: Response) => {
+		const ref = request.params.ref;
+		const file = await handleFileDownload(staging, ref);
+
+		if (file == null) {
+			response.status(404).json({ error: "File not found or expired" });
+			return;
+		}
+
+		response.setHeader("Content-Type", file.mimeType);
+		response.setHeader("Content-Disposition", `inline; filename="${file.filename}"`);
+		response.send(Buffer.from(file.content));
+	});
+
+	// Existing MCP route — update createServer call to pass staging
+	app.post("/mcp", async (request: Request, response: Response) => {
+		// ... existing session logic ...
+		// Change every: const server = await createServer(strategy);
+		// To: const server = await createServer(strategy, staging);
+		// ... rest unchanged ...
+	});
+
+	// ... rest of existing routes unchanged ...
+};
+```
+
+- [ ] **Step 2: Run type check**
+
+Run: `pnpm run types`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main.ts
+git commit -m "feat(local): Wire upload/download routes and staging into local server transports"
+```
+
+---
+
+### Task 11: Wire Upload/Download Routes Into Cloudflare Worker
+
+**Files:**
+- Modify: `wrangler.json`
+- Modify: `src/cloudflare/handler.tsx`
+- Modify: `src/cloudflare/main.ts`
+
+- [ ] **Step 1: Add FILE_STAGING KV namespace to wrangler.json**
+
+First, create the KV namespace:
+
+Run: `pnpm wrangler kv namespace create FILE_STAGING`
+
+This will output an ID. Add the binding to `wrangler.json` in the `kv_namespaces` array:
+
+```json
+{
+  "binding": "FILE_STAGING",
+  "id": "<the-id-from-the-command-above>"
+}
+```
+
+- [ ] **Step 2: Regenerate worker types**
+
+Run: `pnpm cf:generate`
+
+This updates `worker-configuration.d.ts` to include the `FILE_STAGING: KVNamespace` binding.
+
+- [ ] **Step 3: Add upload/download routes to the Hono handler**
+
+Edit `src/cloudflare/handler.tsx`. Add imports:
+
+```typescript
+import { KVFileStaging } from "../staging/kvStorage.js";
+import { handleFileUpload, handleFileDownload } from "../staging/routes.js";
+import { uploadPageHtml } from "../staging/upload-page.js";
+```
+
+Add the following routes BEFORE the existing `/authorize` routes in the `createHandler` function:
+
+```typescript
+// Upload page
+app.get("/upload", (context) => {
+	const baseUrl = new URL(context.req.url).origin;
+	return context.html(uploadPageHtml(baseUrl));
+});
+
+// Upload endpoint
+app.post("/upload", async (context) => {
+	try {
+		const staging = new KVFileStaging(context.env.FILE_STAGING);
+		const formData = await context.req.raw.formData();
+		const file = formData.get("file");
+
+		if (!(file instanceof File)) {
+			return context.json({ error: "No file provided" }, 400);
+		}
+
+		const result = await handleFileUpload(staging, {
+			content: await file.arrayBuffer(),
+			filename: file.name,
+			mimeType: file.type || "application/octet-stream",
+		});
+
+		return context.json(result);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		return context.json({ error: message }, 400);
+	}
+});
+
+// Download endpoint
+app.get("/download/:ref", async (context) => {
+	const ref = context.req.param("ref");
+	const staging = new KVFileStaging(context.env.FILE_STAGING);
+	const file = await handleFileDownload(staging, ref);
+
+	if (file == null) {
+		return context.json({ error: "File not found or expired" }, 404);
+	}
+
+	return new Response(file.content, {
+		headers: {
+			"Content-Type": file.mimeType,
+			"Content-Disposition": `inline; filename="${file.filename}"`,
+		},
+	});
+});
+```
+
+- [ ] **Step 4: Update the FakturoidMCP Durable Object to use KV staging**
+
+Edit `src/cloudflare/main.ts`. Add import:
+
+```typescript
+import { KVFileStaging } from "../staging/kvStorage.js";
+```
+
+Update the `init()` method to create KV staging and pass it to `createServer`:
+
+```typescript
+override async init(): Promise<void> {
+	FakturoidMCP.strategy = createOAuthStrategy(this.env);
+
+	const staging = new KVFileStaging(this.env.FILE_STAGING);
+
+	// biome-ignore lint/complexity/useLiteralKeys: Making TS happy
+	const userId = this.props["userId"];
+	if (userId != null) {
+		FakturoidMCP.strategy.setCurrentUser(userId);
+
+		// biome-ignore lint/complexity/useLiteralKeys: Making TS happy
+		const accessToken = this.props["accessToken"];
+		if (accessToken != null) {
+			await FakturoidMCP.strategy.setUser({
+				userId: userId,
+				accessToken: accessToken,
+			});
+		}
+	}
+
+	this.server = await createServer(FakturoidMCP.strategy, staging);
+}
+```
+
+- [ ] **Step 5: Run type check**
+
+Run: `pnpm run types`
+Expected: No errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add wrangler.json worker-configuration.d.ts src/cloudflare/handler.tsx src/cloudflare/main.ts
+git commit -m "feat(cloudflare): Wire upload/download routes and KV staging into Cloudflare Worker"
+```
+
+---
+
+### Task 12: Run Full Test Suite and Lint
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `pnpm test`
+Expected: All tests PASS
+
+- [ ] **Step 2: Run the linter**
+
+Run: `pnpm run lint`
+Expected: No errors (fix any if found)
+
+- [ ] **Step 3: Run the formatter**
+
+Run: `pnpm run format`
+Expected: All files formatted
+
+- [ ] **Step 4: Run the type checker**
+
+Run: `pnpm run types`
+Expected: No type errors
+
+- [ ] **Step 5: Commit any formatting fixes**
+
+```bash
+git add -A
+git commit -m "chore: Fix formatting after file staging implementation"
+```
+
+(Skip if no changes)
+
+---
+
+### Task 13: Manual Smoke Test
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Start the local HTTP server**
+
+Run: `MCP_TRANSPORT=http pnpm dev`
+Expected: Server starts on port 5173
+
+- [ ] **Step 2: Test the upload page**
+
+Open `http://localhost:5173/upload` in a browser.
+Expected: A drag-and-drop upload page appears.
+
+- [ ] **Step 3: Upload a test file**
+
+Drop a small PDF or PNG file onto the upload page.
+Expected: A reference ID like `ref_a1b2c3...` is displayed with a copy button.
+
+- [ ] **Step 4: Test the download endpoint**
+
+Open `http://localhost:5173/download/<ref_from_step_3>` in a browser.
+Expected: The file downloads/displays in the browser.
+
+- [ ] **Step 5: Stop the server**
+
+Press Ctrl+C to stop the dev server.

--- a/docs/superpowers/plans/2026-04-12-smart-create-tools.md
+++ b/docs/superpowers/plans/2026-04-12-smart-create-tools.md
@@ -1,0 +1,796 @@
+# Smart Create Tools Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add two compound MCP tools (`fakturoid_smart_create_invoice`, `fakturoid_smart_create_expense`) that resolve subjects by IČO, detect duplicate documents, and create documents — all in a single tool call.
+
+**Architecture:** Each tool is a standalone orchestration function that composes existing client methods (`searchSubjects`, `createSubject`, `getInvoices`/`getExpenses`, `createInvoice`/`createExpense`). Both tools share a common subject resolution helper extracted into a shared module. The tools follow the existing `createTool` factory pattern and register alongside existing tools.
+
+**Tech Stack:** TypeScript, Zod v3, MCP SDK, Vitest
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/fakturoid/tool/resolveSubject.ts` | Create | Shared helper: search subject by IČO, create if not found |
+| `src/fakturoid/tool/smartInvoice.ts` | Create | `fakturoid_smart_create_invoice` tool |
+| `src/fakturoid/tool/smartExpense.ts` | Create | `fakturoid_smart_create_expense` tool |
+| `src/fakturoid/tools.ts` | Modify | Register the two new tool arrays |
+| `src/fakturoid/tool/resolveSubject.test.ts` | Create | Tests for subject resolution logic |
+| `src/fakturoid/tool/smartInvoice.test.ts` | Create | Tests for smart invoice tool orchestration |
+| `src/fakturoid/tool/smartExpense.test.ts` | Create | Tests for smart expense tool orchestration |
+
+---
+
+### Task 1: Subject Resolution Helper
+
+**Files:**
+- Create: `src/fakturoid/tool/resolveSubject.ts`
+- Test: `src/fakturoid/tool/resolveSubject.test.ts`
+
+This helper searches for a subject by IČO using `searchSubjects`, filters results for an exact `registration_no` match, and creates the subject via ARES if not found.
+
+- [ ] **Step 1: Write failing tests for `resolveSubject`**
+
+Create `src/fakturoid/tool/resolveSubject.test.ts`:
+
+```typescript
+import { describe, expect, it, vi } from "vitest";
+import { resolveSubject } from "./resolveSubject.js";
+
+const mockClient = {
+	searchSubjects: vi.fn(),
+	createSubject: vi.fn(),
+};
+
+describe("resolveSubject", () => {
+	it("returns existing subject when IČO matches", async () => {
+		const existingSubject = { id: 42, name: "Test Company", registration_no: "12345678" };
+		mockClient.searchSubjects.mockResolvedValue([existingSubject]);
+
+		const result = await resolveSubject(mockClient as any, "12345678", "customer");
+
+		expect(result).toEqual({ status: "found", data: existingSubject });
+		expect(mockClient.searchSubjects).toHaveBeenCalledWith("12345678");
+		expect(mockClient.createSubject).not.toHaveBeenCalled();
+	});
+
+	it("creates subject when no IČO match found", async () => {
+		mockClient.searchSubjects.mockResolvedValue([]);
+		const createdSubject = { id: 99, name: "New Co", registration_no: "87654321" };
+		mockClient.createSubject.mockResolvedValue(createdSubject);
+
+		const result = await resolveSubject(mockClient as any, "87654321", "customer");
+
+		expect(result).toEqual({ status: "created", data: createdSubject });
+		expect(mockClient.createSubject).toHaveBeenCalledWith({
+			name: "87654321",
+			registration_no: "87654321",
+			type: "customer",
+		});
+	});
+
+	it("creates subject when search returns subjects with different IČO", async () => {
+		const otherSubject = { id: 10, name: "Other Co", registration_no: "99999999" };
+		mockClient.searchSubjects.mockResolvedValue([otherSubject]);
+		const createdSubject = { id: 99, name: "New Co", registration_no: "12345678" };
+		mockClient.createSubject.mockResolvedValue(createdSubject);
+
+		const result = await resolveSubject(mockClient as any, "12345678", "customer");
+
+		expect(result).toEqual({ status: "created", data: createdSubject });
+	});
+
+	it("uses 'supplier' type for expenses", async () => {
+		mockClient.searchSubjects.mockResolvedValue([]);
+		mockClient.createSubject.mockResolvedValue({ id: 1, name: "Supplier", registration_no: "11111111" });
+
+		await resolveSubject(mockClient as any, "11111111", "supplier");
+
+		expect(mockClient.createSubject).toHaveBeenCalledWith({
+			name: "11111111",
+			registration_no: "11111111",
+			type: "supplier",
+		});
+	});
+
+	it("returns error when searchSubjects fails", async () => {
+		mockClient.searchSubjects.mockResolvedValue(new Error("API error"));
+
+		const result = await resolveSubject(mockClient as any, "12345678", "customer");
+
+		expect(result).toBeInstanceOf(Error);
+	});
+
+	it("returns error when createSubject fails", async () => {
+		mockClient.searchSubjects.mockResolvedValue([]);
+		mockClient.createSubject.mockResolvedValue(new Error("Validation error"));
+
+		const result = await resolveSubject(mockClient as any, "12345678", "customer");
+
+		expect(result).toBeInstanceOf(Error);
+	});
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run src/fakturoid/tool/resolveSubject.test.ts`
+Expected: FAIL — module `./resolveSubject.js` not found
+
+- [ ] **Step 3: Implement `resolveSubject`**
+
+Create `src/fakturoid/tool/resolveSubject.ts`:
+
+```typescript
+import type { FakturoidClient } from "../client.js";
+import type { Subject } from "../model/subject.js";
+
+type SubjectResolution =
+	| { status: "found"; data: Subject }
+	| { status: "created"; data: Subject };
+
+const resolveSubject = async (
+	client: FakturoidClient<any, any>,
+	registrationNo: string,
+	type: "customer" | "supplier",
+): Promise<SubjectResolution | Error> => {
+	const searchResult = await client.searchSubjects(registrationNo);
+	if (searchResult instanceof Error) {
+		return new Error(`Subject search failed: ${searchResult.message}`);
+	}
+
+	const match = searchResult.find(
+		(subject) => subject.registration_no === registrationNo,
+	);
+
+	if (match != null) {
+		return { status: "found", data: match };
+	}
+
+	const created = await client.createSubject({
+		name: registrationNo,
+		registration_no: registrationNo,
+		type,
+	});
+
+	if (created instanceof Error) {
+		return new Error(`Subject creation failed: ${created.message}`);
+	}
+
+	return { status: "created", data: created };
+};
+
+export { resolveSubject };
+export type { SubjectResolution };
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm vitest run src/fakturoid/tool/resolveSubject.test.ts`
+Expected: All 6 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/fakturoid/tool/resolveSubject.ts src/fakturoid/tool/resolveSubject.test.ts
+git commit -m "feat(tools): Add subject resolution helper for smart create tools"
+```
+
+---
+
+### Task 2: Smart Create Invoice Tool
+
+**Files:**
+- Create: `src/fakturoid/tool/smartInvoice.ts`
+- Test: `src/fakturoid/tool/smartInvoice.test.ts`
+
+- [ ] **Step 1: Write failing tests for smart invoice creation**
+
+Create `src/fakturoid/tool/smartInvoice.test.ts`:
+
+```typescript
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./resolveSubject.js", () => ({
+	resolveSubject: vi.fn(),
+}));
+
+import { resolveSubject } from "./resolveSubject.js";
+import { executeSmartCreateInvoice } from "./smartInvoice.js";
+
+const mockClient = {
+	getInvoices: vi.fn(),
+	createInvoice: vi.fn(),
+};
+
+const mockResolveSubject = vi.mocked(resolveSubject);
+
+describe("executeSmartCreateInvoice", () => {
+	it("creates invoice when subject exists and no duplicate", async () => {
+		const subject = { id: 42, name: "Test Co", registration_no: "12345678" };
+		mockResolveSubject.mockResolvedValue({ status: "found", data: subject as any });
+		mockClient.getInvoices.mockResolvedValue([]);
+		const createdInvoice = { id: 1, number: "2026-001", subject_id: 42 };
+		mockClient.createInvoice.mockResolvedValue(createdInvoice);
+
+		const result = await executeSmartCreateInvoice(mockClient as any, {
+			registration_no: "12345678",
+			number: "2026-001",
+			lines: [{ name: "Service", unit_price: "1000", quantity: "1", vat_rate: 21 }],
+		});
+
+		expect(result).toEqual({
+			status: "created",
+			subject: { status: "found", data: subject },
+			document: { data: createdInvoice },
+		});
+		expect(mockClient.createInvoice).toHaveBeenCalledWith({
+			subject_id: 42,
+			number: "2026-001",
+			lines: [{ name: "Service", unit_price: "1000", quantity: "1", vat_rate: 21 }],
+		});
+	});
+
+	it("creates subject and invoice when subject not found", async () => {
+		const subject = { id: 99, name: "New Co", registration_no: "87654321" };
+		mockResolveSubject.mockResolvedValue({ status: "created", data: subject as any });
+		mockClient.getInvoices.mockResolvedValue([]);
+		const createdInvoice = { id: 2, number: "2026-002", subject_id: 99 };
+		mockClient.createInvoice.mockResolvedValue(createdInvoice);
+
+		const result = await executeSmartCreateInvoice(mockClient as any, {
+			registration_no: "87654321",
+			number: "2026-002",
+		});
+
+		expect(result.status).toBe("created");
+		expect(result.subject.status).toBe("created");
+	});
+
+	it("returns duplicate when invoice number already exists for subject", async () => {
+		const subject = { id: 42, name: "Test Co", registration_no: "12345678" };
+		mockResolveSubject.mockResolvedValue({ status: "found", data: subject as any });
+		const existingInvoice = { id: 5, number: "2026-001", subject_id: 42 };
+		mockClient.getInvoices.mockResolvedValue([existingInvoice]);
+
+		const result = await executeSmartCreateInvoice(mockClient as any, {
+			registration_no: "12345678",
+			number: "2026-001",
+		});
+
+		expect(result).toEqual({
+			status: "duplicate_found",
+			subject: { status: "found", data: subject },
+			document: {
+				data: existingInvoice,
+				message: "Document with this number already exists for this subject. Ask the user whether to update it or leave it as-is.",
+			},
+		});
+		expect(mockClient.createInvoice).not.toHaveBeenCalled();
+	});
+
+	it("skips duplicate check when number is not provided", async () => {
+		const subject = { id: 42, name: "Test Co", registration_no: "12345678" };
+		mockResolveSubject.mockResolvedValue({ status: "found", data: subject as any });
+		const createdInvoice = { id: 3, subject_id: 42 };
+		mockClient.createInvoice.mockResolvedValue(createdInvoice);
+
+		const result = await executeSmartCreateInvoice(mockClient as any, {
+			registration_no: "12345678",
+		});
+
+		expect(result.status).toBe("created");
+		expect(mockClient.getInvoices).not.toHaveBeenCalled();
+	});
+
+	it("returns error when subject resolution fails", async () => {
+		mockResolveSubject.mockResolvedValue(new Error("API error"));
+
+		const result = await executeSmartCreateInvoice(mockClient as any, {
+			registration_no: "12345678",
+		});
+
+		expect(result).toBeInstanceOf(Error);
+	});
+
+	it("returns error when invoice creation fails", async () => {
+		const subject = { id: 42, name: "Test Co", registration_no: "12345678" };
+		mockResolveSubject.mockResolvedValue({ status: "found", data: subject as any });
+		mockClient.getInvoices.mockResolvedValue([]);
+		mockClient.createInvoice.mockResolvedValue(new Error("Validation error"));
+
+		const result = await executeSmartCreateInvoice(mockClient as any, {
+			registration_no: "12345678",
+			number: "2026-001",
+		});
+
+		expect(result).toBeInstanceOf(Error);
+	});
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run src/fakturoid/tool/smartInvoice.test.ts`
+Expected: FAIL — module `./smartInvoice.js` not found
+
+- [ ] **Step 3: Implement smart invoice tool**
+
+Create `src/fakturoid/tool/smartInvoice.ts`:
+
+```typescript
+import { z } from "zod/v3";
+import type { FakturoidClient } from "../client.js";
+import type { Invoice } from "../model/invoice.js";
+import { CreateInvoiceSchema } from "../model/invoice.js";
+import type { Subject } from "../model/subject.js";
+import { createTool, type ServerToolCreator } from "./common.js";
+import { resolveSubject, type SubjectResolution } from "./resolveSubject.js";
+
+type SmartCreateInvoiceResult =
+	| {
+			status: "created" | "duplicate_found";
+			subject: SubjectResolution;
+			document: {
+				data: Invoice;
+				message?: string;
+			};
+	  }
+	| Error;
+
+const DUPLICATE_MESSAGE =
+	"Document with this number already exists for this subject. Ask the user whether to update it or leave it as-is.";
+
+const SmartCreateInvoiceInputSchema = CreateInvoiceSchema.omit({ subject_id: true }).extend({
+	registration_no: z.string().describe("Registration number (IČO) of the subject"),
+});
+
+type SmartCreateInvoiceInput = z.infer<typeof SmartCreateInvoiceInputSchema>;
+
+const executeSmartCreateInvoice = async (
+	client: FakturoidClient<any, any>,
+	input: SmartCreateInvoiceInput,
+): Promise<SmartCreateInvoiceResult> => {
+	const { registration_no, ...invoiceData } = input;
+
+	const subjectResult = await resolveSubject(client, registration_no, "customer");
+	if (subjectResult instanceof Error) {
+		return subjectResult;
+	}
+
+	const subjectId = subjectResult.data.id;
+
+	if (invoiceData.number != null) {
+		const existingInvoices = await client.getInvoices({
+			subject_id: subjectId,
+			number: invoiceData.number,
+		});
+
+		if (existingInvoices instanceof Error) {
+			return new Error(`Invoice search failed: ${existingInvoices.message}`);
+		}
+
+		if (existingInvoices.length > 0) {
+			return {
+				status: "duplicate_found",
+				subject: subjectResult,
+				document: {
+					data: existingInvoices[0] as Invoice,
+					message: DUPLICATE_MESSAGE,
+				},
+			};
+		}
+	}
+
+	const created = await client.createInvoice({
+		...invoiceData,
+		subject_id: subjectId,
+	});
+
+	if (created instanceof Error) {
+		return new Error(`Invoice creation failed: ${created.message}`);
+	}
+
+	return {
+		status: "created",
+		subject: subjectResult,
+		document: { data: created },
+	};
+};
+
+const smartCreateInvoice = createTool(
+	"fakturoid_smart_create_invoice",
+	"Smart Create Invoice",
+	"Resolve subject by IČO (create via ARES if not found), check for duplicate invoice by number, and create the invoice — all in one step. Returns existing document with a message if duplicate is found.",
+	async (client, input) => {
+		const result = await executeSmartCreateInvoice(client, input as SmartCreateInvoiceInput);
+
+		if (result instanceof Error) {
+			return {
+				content: [{ isError: true, text: result.message, type: "text" as const }],
+			};
+		}
+
+		return {
+			content: [{ text: JSON.stringify(result, null, 2), type: "text" as const }],
+		};
+	},
+	SmartCreateInvoiceInputSchema.shape,
+);
+
+const smartInvoice = [smartCreateInvoice] as const satisfies ServerToolCreator[];
+
+export { smartInvoice, executeSmartCreateInvoice };
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm vitest run src/fakturoid/tool/smartInvoice.test.ts`
+Expected: All 6 tests PASS
+
+- [ ] **Step 5: Run type checking**
+
+Run: `pnpm run types`
+Expected: No type errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/fakturoid/tool/smartInvoice.ts src/fakturoid/tool/smartInvoice.test.ts
+git commit -m "feat(tools): Add smart create invoice tool"
+```
+
+---
+
+### Task 3: Smart Create Expense Tool
+
+**Files:**
+- Create: `src/fakturoid/tool/smartExpense.ts`
+- Test: `src/fakturoid/tool/smartExpense.test.ts`
+
+- [ ] **Step 1: Write failing tests for smart expense creation**
+
+Create `src/fakturoid/tool/smartExpense.test.ts`:
+
+```typescript
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./resolveSubject.js", () => ({
+	resolveSubject: vi.fn(),
+}));
+
+import { resolveSubject } from "./resolveSubject.js";
+import { executeSmartCreateExpense } from "./smartExpense.js";
+
+const mockClient = {
+	getExpenses: vi.fn(),
+	createExpense: vi.fn(),
+};
+
+const mockResolveSubject = vi.mocked(resolveSubject);
+
+describe("executeSmartCreateExpense", () => {
+	it("creates expense when subject exists and no duplicate", async () => {
+		const subject = { id: 42, name: "Supplier Co", registration_no: "12345678" };
+		mockResolveSubject.mockResolvedValue({ status: "found", data: subject as any });
+		mockClient.getExpenses.mockResolvedValue([]);
+		const createdExpense = { id: 1, original_number: "FV-2026-001", subject_id: 42 };
+		mockClient.createExpense.mockResolvedValue(createdExpense);
+
+		const result = await executeSmartCreateExpense(mockClient as any, {
+			registration_no: "12345678",
+			original_number: "FV-2026-001",
+			lines: [{ name: "Material", unit_price: "500", quantity: "1", vat_rate: 21 }],
+		});
+
+		expect(result).toEqual({
+			status: "created",
+			subject: { status: "found", data: subject },
+			document: { data: createdExpense },
+		});
+		expect(mockClient.createExpense).toHaveBeenCalledWith({
+			subject_id: 42,
+			original_number: "FV-2026-001",
+			lines: [{ name: "Material", unit_price: "500", quantity: "1", vat_rate: 21 }],
+		});
+	});
+
+	it("creates subject and expense when subject not found", async () => {
+		const subject = { id: 99, name: "New Supplier", registration_no: "87654321" };
+		mockResolveSubject.mockResolvedValue({ status: "created", data: subject as any });
+		mockClient.getExpenses.mockResolvedValue([]);
+		const createdExpense = { id: 2, original_number: "FV-2026-002", subject_id: 99 };
+		mockClient.createExpense.mockResolvedValue(createdExpense);
+
+		const result = await executeSmartCreateExpense(mockClient as any, {
+			registration_no: "87654321",
+			original_number: "FV-2026-002",
+		});
+
+		expect(result.status).toBe("created");
+		expect(result.subject.status).toBe("created");
+	});
+
+	it("returns duplicate when original_number already exists for subject", async () => {
+		const subject = { id: 42, name: "Supplier Co", registration_no: "12345678" };
+		mockResolveSubject.mockResolvedValue({ status: "found", data: subject as any });
+		const existingExpense = { id: 5, original_number: "FV-2026-001", subject_id: 42 };
+		const otherExpense = { id: 6, original_number: "FV-2026-999", subject_id: 42 };
+		mockClient.getExpenses.mockResolvedValue([otherExpense, existingExpense]);
+
+		const result = await executeSmartCreateExpense(mockClient as any, {
+			registration_no: "12345678",
+			original_number: "FV-2026-001",
+		});
+
+		expect(result).toEqual({
+			status: "duplicate_found",
+			subject: { status: "found", data: subject },
+			document: {
+				data: existingExpense,
+				message: "Document with this number already exists for this subject. Ask the user whether to update it or leave it as-is.",
+			},
+		});
+		expect(mockClient.createExpense).not.toHaveBeenCalled();
+	});
+
+	it("skips duplicate check when original_number is not provided", async () => {
+		const subject = { id: 42, name: "Supplier Co", registration_no: "12345678" };
+		mockResolveSubject.mockResolvedValue({ status: "found", data: subject as any });
+		const createdExpense = { id: 3, subject_id: 42 };
+		mockClient.createExpense.mockResolvedValue(createdExpense);
+
+		const result = await executeSmartCreateExpense(mockClient as any, {
+			registration_no: "12345678",
+		});
+
+		expect(result.status).toBe("created");
+		expect(mockClient.getExpenses).not.toHaveBeenCalled();
+	});
+
+	it("resolves subject as supplier type", async () => {
+		const subject = { id: 42, name: "Supplier Co", registration_no: "12345678" };
+		mockResolveSubject.mockResolvedValue({ status: "found", data: subject as any });
+		mockClient.getExpenses.mockResolvedValue([]);
+		mockClient.createExpense.mockResolvedValue({ id: 1, subject_id: 42 });
+
+		await executeSmartCreateExpense(mockClient as any, {
+			registration_no: "12345678",
+		});
+
+		expect(mockResolveSubject).toHaveBeenCalledWith(mockClient, "12345678", "supplier");
+	});
+
+	it("returns error when subject resolution fails", async () => {
+		mockResolveSubject.mockResolvedValue(new Error("API error"));
+
+		const result = await executeSmartCreateExpense(mockClient as any, {
+			registration_no: "12345678",
+		});
+
+		expect(result).toBeInstanceOf(Error);
+	});
+
+	it("returns error when expense creation fails", async () => {
+		const subject = { id: 42, name: "Supplier Co", registration_no: "12345678" };
+		mockResolveSubject.mockResolvedValue({ status: "found", data: subject as any });
+		mockClient.getExpenses.mockResolvedValue([]);
+		mockClient.createExpense.mockResolvedValue(new Error("Validation error"));
+
+		const result = await executeSmartCreateExpense(mockClient as any, {
+			registration_no: "12345678",
+			original_number: "FV-2026-001",
+		});
+
+		expect(result).toBeInstanceOf(Error);
+	});
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run src/fakturoid/tool/smartExpense.test.ts`
+Expected: FAIL — module `./smartExpense.js` not found
+
+- [ ] **Step 3: Implement smart expense tool**
+
+Create `src/fakturoid/tool/smartExpense.ts`:
+
+```typescript
+import { z } from "zod/v3";
+import type { FakturoidClient } from "../client.js";
+import type { Expense } from "../model/expense.js";
+import { CreateExpenseSchema } from "../model/expense.js";
+import type { Subject } from "../model/subject.js";
+import { createTool, type ServerToolCreator } from "./common.js";
+import { resolveSubject, type SubjectResolution } from "./resolveSubject.js";
+
+type SmartCreateExpenseResult =
+	| {
+			status: "created" | "duplicate_found";
+			subject: SubjectResolution;
+			document: {
+				data: Expense;
+				message?: string;
+			};
+	  }
+	| Error;
+
+const DUPLICATE_MESSAGE =
+	"Document with this number already exists for this subject. Ask the user whether to update it or leave it as-is.";
+
+const SmartCreateExpenseInputSchema = CreateExpenseSchema.omit({ subject_id: true }).extend({
+	registration_no: z.string().describe("Registration number (IČO) of the subject"),
+});
+
+type SmartCreateExpenseInput = z.infer<typeof SmartCreateExpenseInputSchema>;
+
+const executeSmartCreateExpense = async (
+	client: FakturoidClient<any, any>,
+	input: SmartCreateExpenseInput,
+): Promise<SmartCreateExpenseResult> => {
+	const { registration_no, ...expenseData } = input;
+
+	const subjectResult = await resolveSubject(client, registration_no, "supplier");
+	if (subjectResult instanceof Error) {
+		return subjectResult;
+	}
+
+	const subjectId = subjectResult.data.id;
+
+	if (expenseData.original_number != null) {
+		const existingExpenses = await client.getExpenses({
+			subject_id: subjectId,
+		});
+
+		if (existingExpenses instanceof Error) {
+			return new Error(`Expense search failed: ${existingExpenses.message}`);
+		}
+
+		const duplicate = existingExpenses.find(
+			(e) => e.original_number === expenseData.original_number,
+		);
+
+		if (duplicate != null) {
+			return {
+				status: "duplicate_found",
+				subject: subjectResult,
+				document: {
+					data: duplicate as Expense,
+					message: DUPLICATE_MESSAGE,
+				},
+			};
+		}
+	}
+
+	const created = await client.createExpense({
+		...expenseData,
+		subject_id: subjectId,
+	});
+
+	if (created instanceof Error) {
+		return new Error(`Expense creation failed: ${created.message}`);
+	}
+
+	return {
+		status: "created",
+		subject: subjectResult,
+		document: { data: created },
+	};
+};
+
+const smartCreateExpense = createTool(
+	"fakturoid_smart_create_expense",
+	"Smart Create Expense",
+	"Resolve subject by IČO (create via ARES if not found), check for duplicate expense by original number, and create the expense — all in one step. Returns existing document with a message if duplicate is found.",
+	async (client, input) => {
+		const result = await executeSmartCreateExpense(client, input as SmartCreateExpenseInput);
+
+		if (result instanceof Error) {
+			return {
+				content: [{ isError: true, text: result.message, type: "text" as const }],
+			};
+		}
+
+		return {
+			content: [{ text: JSON.stringify(result, null, 2), type: "text" as const }],
+		};
+	},
+	SmartCreateExpenseInputSchema.shape,
+);
+
+const smartExpense = [smartCreateExpense] as const satisfies ServerToolCreator[];
+
+export { smartExpense, executeSmartCreateExpense };
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm vitest run src/fakturoid/tool/smartExpense.test.ts`
+Expected: All 7 tests PASS
+
+- [ ] **Step 5: Run type checking**
+
+Run: `pnpm run types`
+Expected: No type errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/fakturoid/tool/smartExpense.ts src/fakturoid/tool/smartExpense.test.ts
+git commit -m "feat(tools): Add smart create expense tool"
+```
+
+---
+
+### Task 4: Register Tools and Final Verification
+
+**Files:**
+- Modify: `src/fakturoid/tools.ts:1-59`
+
+- [ ] **Step 1: Add imports and register smart tools**
+
+In `src/fakturoid/tools.ts`, add two imports after the existing tool imports (after line 23, before the function):
+
+```typescript
+import { smartExpense } from "./tool/smartExpense.js";
+import { smartInvoice } from "./tool/smartInvoice.js";
+```
+
+Add `smartExpense` and `smartInvoice` to the tools array (after `webhook` on line 51):
+
+```typescript
+const tools: ServerToolCreator<Configuration, Strategy>[] = [
+	account,
+	bankAccount,
+	event,
+	expense,
+	expensePayment,
+	generator,
+	inboxFile,
+	inventoryItem,
+	inventoryMove,
+	invoice,
+	invoiceMessage,
+	invoicePayment,
+	meta,
+	numberFormat,
+	recurringGenerator,
+	smartExpense,
+	smartInvoice,
+	subject,
+	todo,
+	user,
+	webhook,
+].flat();
+```
+
+- [ ] **Step 2: Run all tests**
+
+Run: `pnpm vitest run`
+Expected: All tests PASS
+
+- [ ] **Step 3: Run type checking**
+
+Run: `pnpm run types`
+Expected: No type errors
+
+- [ ] **Step 4: Run linting**
+
+Run: `pnpm run lint`
+Expected: No lint errors (run `pnpm run format` first if needed)
+
+- [ ] **Step 5: Build**
+
+Run: `pnpm run build`
+Expected: Successful compilation
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/fakturoid/tools.ts
+git commit -m "feat(tools): Register smart create invoice and expense tools"
+```

--- a/docs/superpowers/specs/2026-04-12-file-upload-staging-design.md
+++ b/docs/superpowers/specs/2026-04-12-file-upload-staging-design.md
@@ -1,0 +1,268 @@
+# File Upload Staging Design
+
+## Problem
+
+When an AI agent (e.g., Claude) uploads file attachments (PDFs, PNGs) through this MCP server, the file content must be passed as base64-encoded strings in MCP tool arguments. This causes the LLM's context window to be exhausted because:
+
+1. **Output token cost**: The LLM must *generate* the entire base64 string as output tokens in the tool call
+2. **Context retention**: Both the tool arguments and results persist in the conversation context
+3. **Scale**: A 1MB PDF becomes ~1.3MB of base64 — hundreds of thousands of tokens
+
+This affects three upload paths:
+- `fakturoid_create_inbox_file` — `attachment` field (base64 string)
+- `fakturoid_create_invoice` — `attachments[].data_url` field (data URI)
+- `fakturoid_create_expense` — `attachments[].data_url` field (data URI)
+
+And three download paths that return binary as JSON text:
+- `fakturoid_download_invoice_pdf`
+- `fakturoid_download_invoice_attachment`
+- `fakturoid_download_expense_attachment`
+
+## Constraints
+
+- The MCP server is primarily used via Cloudflare Workers deployment (no local filesystem)
+- Must also work for local development (stdio + HTTP transports)
+- MCP protocol has no out-of-band binary channel for tool inputs — tool arguments are JSON
+- The LLM constructs tool calls, so any file content in arguments = context tokens consumed
+
+## Solution: Two-Phase Upload with File Staging
+
+### Overview
+
+Add an HTTP upload endpoint to the server that accepts file uploads directly (bypassing the LLM context), stores them temporarily, and returns a short reference ID. MCP tools then accept this reference ID instead of raw file content.
+
+**Upload flow:**
+```
+User opens /upload page in browser
+  → Drops file
+  → File stored in staging (KV with TTL on CF, in-memory Map locally)
+  → Returns reference ID (e.g., "ref_a1b2c3d4")
+
+User tells Claude: "upload invoice ref_a1b2c3d4 to inbox"
+
+Claude calls: fakturoid_create_inbox_file({ file_ref: "ref_a1b2c3d4", ... })
+  → Server retrieves staged file by ref
+  → Converts to base64, sends to Fakturoid API
+  → Deletes staged file
+  → Returns success response
+```
+
+**Context cost: ~30 tokens instead of hundreds of thousands.**
+
+### File Source Priority
+
+Tools accept multiple source options (exactly one required):
+
+| Source | Description | Works on CF | Works locally |
+|--------|-------------|-------------|---------------|
+| `file_ref` | Reference ID from upload endpoint | Yes | Yes (HTTP mode) |
+| `source_url` | URL to fetch file from | Yes | Yes |
+| `file_path` | Local filesystem path | No | Yes (stdio/HTTP) |
+| `data` | Raw base64/data URI (fallback) | Yes | Yes |
+
+The tool description guides the AI agent on preference order.
+
+### Components
+
+#### 1. Upload Endpoint & Page
+
+**Route**: `GET /upload` — serves a simple HTML page with drag-and-drop file upload UI.
+
+**Route**: `POST /upload` — accepts `multipart/form-data` with a single file field.
+
+**Response**:
+```json
+{
+  "file_ref": "ref_a1b2c3d4e5f6",
+  "filename": "invoice.pdf",
+  "size": 102400,
+  "mime_type": "application/pdf",
+  "expires_in_seconds": 300
+}
+```
+
+**Constraints**:
+- Max file size: 10MB (Fakturoid API limit is likely similar)
+- Allowed MIME types: `application/pdf`, `image/png`, `image/jpeg`, `image/gif`, `text/xml`, `application/xml`
+- Files expire after 5 minutes (TTL)
+- Reference IDs are random UUIDs prefixed with `ref_`
+
+**Upload page UI**: Minimal HTML — drag-and-drop zone, file input button, displays reference ID after upload with a copy button. No framework needed, inline CSS/JS. Must be functional, not fancy.
+
+#### 2. File Staging Storage
+
+**Cloudflare Workers**: Add a new `FILE_STAGING` KV namespace with TTL-based expiration.
+
+- Key: `file_staging:{ref_id}`
+- Value: File content as base64 string
+- Metadata: `{ filename, mime_type, size, created_at }`
+- TTL: 300 seconds (5 minutes)
+
+**Local (HTTP mode)**: In-memory `Map<string, StagedFile>` with a cleanup interval that removes expired entries every 60 seconds.
+
+**Local (stdio mode)**: No staging needed — file_path reads directly from disk. But the Map is still available if someone uses the HTTP transport locally.
+
+#### 3. File Resolution Service
+
+A shared utility that resolves any of the four source types to a `{ data: Buffer/ArrayBuffer, filename: string, mimeType: string }`:
+
+```typescript
+interface FileSource {
+  file_ref?: string;
+  source_url?: string;
+  file_path?: string;
+  data?: string;
+}
+
+interface ResolvedFile {
+  content: ArrayBuffer;
+  filename: string;
+  mimeType: string;
+}
+
+async function resolveFileSource(
+  source: FileSource,
+  staging: FileStaging
+): Promise<ResolvedFile>
+```
+
+**Resolution logic**:
+1. Validate exactly one source is provided
+2. `file_ref` → look up in staging storage, delete after retrieval
+3. `source_url` → `fetch(url)`, read response body
+4. `file_path` → `fs.readFile()` (throws if running on CF Workers)
+5. `data` → decode base64/data URI directly
+
+This utility is used by all three upload tools.
+
+#### 4. Updated Tool Input Schemas
+
+**`fakturoid_create_inbox_file`** — Replace `attachment: z.string()` with:
+```typescript
+{
+  file_ref: z.string().optional(),
+  source_url: z.string().url().optional(),
+  file_path: z.string().optional(),
+  attachment: z.string().optional(),  // base64 fallback, renamed from required to optional
+  filename: z.string().optional(),
+  send_to_ocr: z.boolean().optional(),
+}
+```
+
+Tool implementation: resolve file source → convert to base64 → call existing `client.createInboxFile()`.
+
+**`fakturoid_create_invoice`** and **`fakturoid_create_expense`** — Extend `CreateAttachmentSchema` alternatives:
+```typescript
+{
+  file_ref: z.string().optional(),
+  source_url: z.string().url().optional(),
+  file_path: z.string().optional(),
+  data_url: z.string().optional(),  // existing field, now optional
+  filename: z.string().optional(),
+}
+```
+
+Tool implementation: for each attachment in the array, resolve file source → convert to data URI → pass to existing client methods.
+
+#### 5. Download Improvements
+
+The download tools currently return `JSON.stringify(blob)` which is meaningless. Improve them to return useful metadata instead of binary content in context:
+
+**`fakturoid_download_invoice_pdf`**:
+- Stage the downloaded binary in the file staging storage (same KV/Map used for uploads)
+- Return a text result: `"Invoice PDF downloaded. File ref: ref_xxx (expires in 5 minutes). Size: 102KB. Access via /download/ref_xxx"`
+- Add a `GET /download/:ref` endpoint that serves staged files as HTTP responses with correct `Content-Type` and `Content-Disposition` headers
+- This lets the user open the file in their browser without the binary ever entering LLM context
+
+**`fakturoid_download_invoice_attachment`** and **`fakturoid_download_expense_attachment`**: Same pattern — stage binary in file staging, return a text result with the file ref and download URL.
+
+### Integration Points
+
+#### Cloudflare Worker (`src/cloudflare/main.ts` + `src/cloudflare/handler.tsx`)
+
+Add routes to the Hono handler:
+- `GET /upload` — serves the upload HTML page
+- `POST /upload` — handles file upload, stores in KV, returns ref
+- `GET /download/:ref` — serves a staged file as an HTTP download
+
+Add a new KV namespace binding `FILE_STAGING` in `wrangler.json`.
+
+The `FakturoidMCP` Durable Object needs access to the KV namespace to resolve `file_ref` values during tool execution.
+
+#### Local Server (`src/main.ts`)
+
+For HTTP transport: add `/upload` GET and POST, and `/download/:ref` GET routes to the Express app.
+
+For stdio transport: no upload endpoint (no HTTP server). The `file_path` source type handles local files. The file resolution service detects the runtime and enables/disables `file_path` accordingly.
+
+#### Tool Registration (`src/fakturoid/tool/common.ts`)
+
+The `createTool` helper needs no changes. Individual tool files update their input schemas and implementations to use the file resolution service.
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `src/staging/storage.ts` | `FileStaging` interface + KV and in-memory implementations |
+| `src/staging/resolver.ts` | `resolveFileSource()` — resolves any source type to file content |
+| `src/staging/upload.ts` | Upload route handlers (shared between Express and Hono) |
+| `src/staging/download.ts` | Download route handler for serving staged files |
+| `src/staging/upload-page.ts` | HTML template for the upload page |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `src/fakturoid/model/inboxFile.ts` | Add file source fields to `CreateInboxFileSchema` |
+| `src/fakturoid/model/common.ts` | Add file source fields to `CreateAttachmentSchema` |
+| `src/fakturoid/tool/inboxFile.ts` | Use file resolver before calling client |
+| `src/fakturoid/tool/invoice.ts` | Resolve attachment sources before calling client |
+| `src/fakturoid/tool/expense.ts` | Resolve attachment sources before calling client |
+| `src/fakturoid/tool/invoice.ts` | Improve download tool return values |
+| `src/fakturoid/tool/expense.ts` | Improve download tool return values |
+| `src/cloudflare/handler.tsx` | Add `/upload` routes |
+| `src/cloudflare/main.ts` | Pass KV binding to staging storage |
+| `src/main.ts` | Add `/upload` routes for local HTTP mode |
+| `src/server.ts` | Accept and pass staging storage to tool registration |
+| `src/fakturoid/tools.ts` | Pass staging storage through to tools |
+| `src/fakturoid/tool/common.ts` | Update `createTool` signature to accept staging storage |
+| `wrangler.json` | Add `FILE_STAGING` KV namespace binding |
+| `worker-configuration.d.ts` | Regenerate with new binding |
+
+### Error Handling
+
+| Error | Behavior |
+|-------|----------|
+| No source provided | Return error: "Provide one of: file_ref, source_url, file_path, or data" |
+| Multiple sources provided | Return error: "Provide exactly one file source" |
+| `file_ref` not found / expired | Return error: "File reference not found or expired. Upload the file again at /upload" |
+| `file_path` on Cloudflare | Return error: "file_path is not supported on the hosted deployment. Use /upload page to get a file_ref instead" |
+| `source_url` fetch fails | Return error with HTTP status: "Failed to fetch file from URL: {status}" |
+| File too large | Return error: "File exceeds maximum size of 10MB" |
+| Invalid MIME type | Return error: "Unsupported file type. Allowed: PDF, PNG, JPEG, GIF, XML" |
+
+### Testing Strategy
+
+- Unit tests for `resolveFileSource()` with each source type
+- Unit tests for staging storage (KV mock + in-memory)
+- Integration test: upload file via POST → get ref → use ref in tool call
+- Test validation: multiple sources, missing sources, expired refs, size limits
+- Test both local (in-memory) and KV storage implementations
+
+### Security Considerations
+
+- File refs are random UUIDs — not guessable
+- TTL ensures files are cleaned up even if never consumed
+- Files are deleted from staging immediately after successful retrieval
+- Upload endpoint is behind the same OAuth protection as the MCP endpoints on Cloudflare
+- Local mode upload endpoint has no auth (acceptable for local development)
+- MIME type validation prevents uploading unexpected file types
+- File size limit prevents abuse
+
+### Out of Scope
+
+- Multi-file upload in a single request (use multiple individual uploads)
+- Resumable uploads (files are small enough for single-shot)
+- File deduplication
+- Persistent file storage beyond TTL
+- Download staging (returning file_ref for downloads) — may be added later

--- a/docs/superpowers/specs/2026-04-12-smart-create-tools-design.md
+++ b/docs/superpowers/specs/2026-04-12-smart-create-tools-design.md
@@ -46,7 +46,8 @@ For duplicate detection:
        - type: "customer" (invoice) or "supplier" (expense)
 
 3. Duplicate check (only if number/original_number is provided)
-   └─ Query existing documents filtered by subject_id + number/original_number
+   └─ Invoice: query by subject_id + number filter
+   └─ Expense: query by subject_id, then client-side filter on original_number (API does not support original_number filter)
 
 4. Document resolution
    ├─ Duplicate found → return existing document with "duplicate_found" status

--- a/docs/superpowers/specs/2026-04-12-smart-create-tools-design.md
+++ b/docs/superpowers/specs/2026-04-12-smart-create-tools-design.md
@@ -1,0 +1,111 @@
+# Smart Create Tools Design Spec
+
+## Problem
+
+When an AI agent needs to create an invoice or expense, it currently must orchestrate 3-4 sequential tool calls: search for the subject by IČO, optionally create the subject, check if the document already exists, then create it. Each round-trip burns tokens and adds latency. This spec defines two compound tools that encapsulate this workflow into a single MCP tool call.
+
+## Tools
+
+Two new tools, following the same factory pattern as existing tools:
+
+- `fakturoid_smart_create_invoice` — resolve subject + deduplicate + create invoice
+- `fakturoid_smart_create_expense` — resolve subject + deduplicate + create expense
+
+These are additive. All existing atomic tools remain unchanged and available.
+
+## Input Schema
+
+Each tool accepts a flat input with two sections:
+
+### Subject Identification
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `registration_no` | string | yes | IČO — used to find or create the subject |
+
+### Document Data
+
+All fields from the existing `CreateInvoiceSchema` (for invoice tool) or `CreateExpenseSchema` (for expense tool), **except `subject_id`**, which is resolved internally from the IČO.
+
+For duplicate detection:
+- Invoice tool uses the `number` field (číslo faktury)
+- Expense tool uses the `original_number` field (číslo faktury dodavatele)
+
+## Execution Flow
+
+```
+1. Search subject by IČO
+   └─ Call searchSubjects(registration_no)
+   └─ Filter results where registration_no matches exactly
+
+2. Subject resolution
+   ├─ Found → use existing subject_id
+   └─ Not found → create subject:
+       - name: registration_no (ARES auto-fill replaces it)
+       - registration_no: the provided IČO
+       - type: "customer" (invoice) or "supplier" (expense)
+
+3. Duplicate check (only if number/original_number is provided)
+   └─ Query existing documents filtered by subject_id + number/original_number
+
+4. Document resolution
+   ├─ Duplicate found → return existing document with "duplicate_found" status
+   └─ No duplicate → create the document with resolved subject_id
+```
+
+## Response Structure
+
+```typescript
+{
+  status: "created" | "duplicate_found",
+  subject: {
+    status: "found" | "created",
+    data: Subject
+  },
+  document: {
+    data: Invoice | Expense,
+    message?: string  // Present only when status is "duplicate_found"
+  }
+}
+```
+
+When `status` is `"duplicate_found"`, the response includes:
+- The full existing document data
+- A message: `"Document with this number already exists for this subject. Ask the user whether to update it or leave it as-is."`
+
+The AI agent then asks the user. If the user wants to update, the agent calls the existing `fakturoid_update_invoice` or `fakturoid_update_expense` tool with the document ID.
+
+## Error Handling
+
+Each step can fail independently. The tool returns a clear error indicating which step failed:
+
+- Subject search failed → API error with context
+- Subject creation failed → validation error (e.g., invalid IČO, ARES lookup failure)
+- Document search failed → API error with context
+- Document creation failed → validation error (e.g., missing required line items)
+
+Errors are returned immediately — the tool does not continue past a failure.
+
+## File Structure
+
+| File | Purpose |
+|---|---|
+| `src/fakturoid/tool/smartInvoice.ts` | `fakturoid_smart_create_invoice` tool |
+| `src/fakturoid/tool/smartExpense.ts` | `fakturoid_smart_create_expense` tool |
+
+Each file exports a `ServerToolCreator` array registered in `src/fakturoid/tools.ts`.
+
+No new client modules or models are needed. The tools compose existing client functions:
+- `searchSubjects`, `createSubject` (from subject client)
+- `getInvoices` / `getExpenses` with filters (from invoice/expense clients)
+- `createInvoice` / `createExpense` (from invoice/expense clients)
+
+The input schema is derived from existing `CreateInvoiceSchema` / `CreateExpenseSchema` with `subject_id` replaced by `registration_no`.
+
+## What Stays Unchanged
+
+- All existing atomic tools (no removals, no modifications)
+- Client layer (`src/fakturoid/client/`)
+- Models (`src/fakturoid/model/`)
+- Server factory (`src/server.ts`)
+- Transport layer (`src/main.ts`)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 packages:
-  - ‘src/*’
+  - 'src/*'
 
 onlyBuiltDependencies:
   - core-js-pure

--- a/src/fakturoid/tool/resolveSubject.test.ts
+++ b/src/fakturoid/tool/resolveSubject.test.ts
@@ -11,6 +11,7 @@ describe("resolveSubject", () => {
 		const existingSubject = { id: 42, name: "Test Company", registration_no: "12345678" };
 		mockClient.searchSubjects.mockResolvedValue([existingSubject]);
 
+		// biome-ignore lint/suspicious/noExplicitAny: mock client doesn't implement full FakturoidClient interface
 		const result = await resolveSubject(mockClient as any, "12345678", "customer");
 
 		expect(result).toEqual({ status: "found", data: existingSubject });
@@ -23,6 +24,7 @@ describe("resolveSubject", () => {
 		const createdSubject = { id: 99, name: "New Co", registration_no: "87654321" };
 		mockClient.createSubject.mockResolvedValue(createdSubject);
 
+		// biome-ignore lint/suspicious/noExplicitAny: mock client doesn't implement full FakturoidClient interface
 		const result = await resolveSubject(mockClient as any, "87654321", "customer");
 
 		expect(result).toEqual({ status: "created", data: createdSubject });
@@ -39,6 +41,7 @@ describe("resolveSubject", () => {
 		const createdSubject = { id: 99, name: "New Co", registration_no: "12345678" };
 		mockClient.createSubject.mockResolvedValue(createdSubject);
 
+		// biome-ignore lint/suspicious/noExplicitAny: mock client doesn't implement full FakturoidClient interface
 		const result = await resolveSubject(mockClient as any, "12345678", "customer");
 
 		expect(result).toEqual({ status: "created", data: createdSubject });
@@ -48,6 +51,7 @@ describe("resolveSubject", () => {
 		mockClient.searchSubjects.mockResolvedValue([]);
 		mockClient.createSubject.mockResolvedValue({ id: 1, name: "Supplier", registration_no: "11111111" });
 
+		// biome-ignore lint/suspicious/noExplicitAny: mock client doesn't implement full FakturoidClient interface
 		await resolveSubject(mockClient as any, "11111111", "supplier");
 
 		expect(mockClient.createSubject).toHaveBeenCalledWith({
@@ -60,6 +64,7 @@ describe("resolveSubject", () => {
 	it("returns error when searchSubjects fails", async () => {
 		mockClient.searchSubjects.mockResolvedValue(new Error("API error"));
 
+		// biome-ignore lint/suspicious/noExplicitAny: mock client doesn't implement full FakturoidClient interface
 		const result = await resolveSubject(mockClient as any, "12345678", "customer");
 
 		expect(result).toBeInstanceOf(Error);
@@ -69,6 +74,7 @@ describe("resolveSubject", () => {
 		mockClient.searchSubjects.mockResolvedValue([]);
 		mockClient.createSubject.mockResolvedValue(new Error("Validation error"));
 
+		// biome-ignore lint/suspicious/noExplicitAny: mock client doesn't implement full FakturoidClient interface
 		const result = await resolveSubject(mockClient as any, "12345678", "customer");
 
 		expect(result).toBeInstanceOf(Error);

--- a/src/fakturoid/tool/resolveSubject.test.ts
+++ b/src/fakturoid/tool/resolveSubject.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveSubject } from "./resolveSubject.js";
+
+const mockClient = {
+	searchSubjects: vi.fn(),
+	createSubject: vi.fn(),
+};
+
+describe("resolveSubject", () => {
+	it("returns existing subject when IČO matches", async () => {
+		const existingSubject = { id: 42, name: "Test Company", registration_no: "12345678" };
+		mockClient.searchSubjects.mockResolvedValue([existingSubject]);
+
+		const result = await resolveSubject(mockClient as any, "12345678", "customer");
+
+		expect(result).toEqual({ status: "found", data: existingSubject });
+		expect(mockClient.searchSubjects).toHaveBeenCalledWith("12345678");
+		expect(mockClient.createSubject).not.toHaveBeenCalled();
+	});
+
+	it("creates subject when no IČO match found", async () => {
+		mockClient.searchSubjects.mockResolvedValue([]);
+		const createdSubject = { id: 99, name: "New Co", registration_no: "87654321" };
+		mockClient.createSubject.mockResolvedValue(createdSubject);
+
+		const result = await resolveSubject(mockClient as any, "87654321", "customer");
+
+		expect(result).toEqual({ status: "created", data: createdSubject });
+		expect(mockClient.createSubject).toHaveBeenCalledWith({
+			name: "87654321",
+			registration_no: "87654321",
+			type: "customer",
+		});
+	});
+
+	it("creates subject when search returns subjects with different IČO", async () => {
+		const otherSubject = { id: 10, name: "Other Co", registration_no: "99999999" };
+		mockClient.searchSubjects.mockResolvedValue([otherSubject]);
+		const createdSubject = { id: 99, name: "New Co", registration_no: "12345678" };
+		mockClient.createSubject.mockResolvedValue(createdSubject);
+
+		const result = await resolveSubject(mockClient as any, "12345678", "customer");
+
+		expect(result).toEqual({ status: "created", data: createdSubject });
+	});
+
+	it("uses 'supplier' type for expenses", async () => {
+		mockClient.searchSubjects.mockResolvedValue([]);
+		mockClient.createSubject.mockResolvedValue({ id: 1, name: "Supplier", registration_no: "11111111" });
+
+		await resolveSubject(mockClient as any, "11111111", "supplier");
+
+		expect(mockClient.createSubject).toHaveBeenCalledWith({
+			name: "11111111",
+			registration_no: "11111111",
+			type: "supplier",
+		});
+	});
+
+	it("returns error when searchSubjects fails", async () => {
+		mockClient.searchSubjects.mockResolvedValue(new Error("API error"));
+
+		const result = await resolveSubject(mockClient as any, "12345678", "customer");
+
+		expect(result).toBeInstanceOf(Error);
+	});
+
+	it("returns error when createSubject fails", async () => {
+		mockClient.searchSubjects.mockResolvedValue([]);
+		mockClient.createSubject.mockResolvedValue(new Error("Validation error"));
+
+		const result = await resolveSubject(mockClient as any, "12345678", "customer");
+
+		expect(result).toBeInstanceOf(Error);
+	});
+});

--- a/src/fakturoid/tool/resolveSubject.ts
+++ b/src/fakturoid/tool/resolveSubject.ts
@@ -1,9 +1,7 @@
 import type { FakturoidClient } from "../client.js";
 import type { Subject } from "../model/subject.js";
 
-type SubjectResolution =
-	| { status: "found"; data: Subject }
-	| { status: "created"; data: Subject };
+type SubjectResolution = { status: "found"; data: Subject } | { status: "created"; data: Subject };
 
 const resolveSubject = async (
 	client: FakturoidClient<any, any>,
@@ -15,9 +13,7 @@ const resolveSubject = async (
 		return new Error(`Subject search failed: ${searchResult.message}`);
 	}
 
-	const match = searchResult.find(
-		(subject) => subject.registration_no === registrationNo,
-	);
+	const match = searchResult.find((subject) => subject.registration_no === registrationNo);
 
 	if (match != null) {
 		return { status: "found", data: match };

--- a/src/fakturoid/tool/resolveSubject.ts
+++ b/src/fakturoid/tool/resolveSubject.ts
@@ -1,10 +1,14 @@
+import type { AuthenticationStrategy } from "../../auth/strategy.js";
 import type { FakturoidClient } from "../client.js";
 import type { Subject } from "../model/subject.js";
 
 type SubjectResolution = { status: "found"; data: Subject } | { status: "created"; data: Subject };
 
-const resolveSubject = async (
-	client: FakturoidClient<any, any>,
+const resolveSubject = async <
+	Configuration extends object = object,
+	Strategy extends AuthenticationStrategy<Configuration> = AuthenticationStrategy<Configuration>,
+>(
+	client: FakturoidClient<Configuration, Strategy>,
 	registrationNo: string,
 	type: "customer" | "supplier",
 ): Promise<SubjectResolution | Error> => {
@@ -22,7 +26,7 @@ const resolveSubject = async (
 	const created = await client.createSubject({
 		name: registrationNo,
 		registration_no: registrationNo,
-		type,
+		type: type,
 	});
 
 	if (created instanceof Error) {

--- a/src/fakturoid/tool/resolveSubject.ts
+++ b/src/fakturoid/tool/resolveSubject.ts
@@ -1,0 +1,40 @@
+import type { FakturoidClient } from "../client.js";
+import type { Subject } from "../model/subject.js";
+
+type SubjectResolution =
+	| { status: "found"; data: Subject }
+	| { status: "created"; data: Subject };
+
+const resolveSubject = async (
+	client: FakturoidClient<any, any>,
+	registrationNo: string,
+	type: "customer" | "supplier",
+): Promise<SubjectResolution | Error> => {
+	const searchResult = await client.searchSubjects(registrationNo);
+	if (searchResult instanceof Error) {
+		return new Error(`Subject search failed: ${searchResult.message}`);
+	}
+
+	const match = searchResult.find(
+		(subject) => subject.registration_no === registrationNo,
+	);
+
+	if (match != null) {
+		return { status: "found", data: match };
+	}
+
+	const created = await client.createSubject({
+		name: registrationNo,
+		registration_no: registrationNo,
+		type,
+	});
+
+	if (created instanceof Error) {
+		return new Error(`Subject creation failed: ${created.message}`);
+	}
+
+	return { status: "created", data: created };
+};
+
+export { resolveSubject };
+export type { SubjectResolution };

--- a/src/fakturoid/tool/smartExpense.test.ts
+++ b/src/fakturoid/tool/smartExpense.test.ts
@@ -4,6 +4,7 @@ vi.mock("./resolveSubject.js", () => ({
 	resolveSubject: vi.fn(),
 }));
 
+import type { Subject } from "../model/subject.js";
 import { resolveSubject } from "./resolveSubject.js";
 import { executeSmartCreateExpense } from "./smartExpense.js";
 
@@ -20,12 +21,13 @@ describe("executeSmartCreateExpense", () => {
 	});
 
 	it("creates expense when subject exists and no duplicate", async () => {
-		const subject = { id: 42, name: "Supplier Co", registration_no: "12345678" };
-		mockResolveSubject.mockResolvedValue({ status: "found", data: subject as any });
+		const subject = { id: 42, name: "Supplier Co", registration_no: "12345678" } as Subject;
+		mockResolveSubject.mockResolvedValue({ status: "found", data: subject });
 		mockClient.getExpenses.mockResolvedValue([]);
 		const createdExpense = { id: 1, original_number: "FV-2026-001", subject_id: 42 };
 		mockClient.createExpense.mockResolvedValue(createdExpense);
 
+		// biome-ignore lint/suspicious/noExplicitAny: mock client doesn't implement full FakturoidClient interface
 		const result = await executeSmartCreateExpense(mockClient as any, {
 			registration_no: "12345678",
 			original_number: "FV-2026-001",
@@ -45,28 +47,34 @@ describe("executeSmartCreateExpense", () => {
 	});
 
 	it("creates subject and expense when subject not found", async () => {
-		const subject = { id: 99, name: "New Supplier", registration_no: "87654321" };
-		mockResolveSubject.mockResolvedValue({ status: "created", data: subject as any });
+		const subject = { id: 99, name: "New Supplier", registration_no: "87654321" } as Subject;
+		mockResolveSubject.mockResolvedValue({ status: "created", data: subject });
 		mockClient.getExpenses.mockResolvedValue([]);
 		const createdExpense = { id: 2, original_number: "FV-2026-002", subject_id: 99 };
 		mockClient.createExpense.mockResolvedValue(createdExpense);
 
+		// biome-ignore lint/suspicious/noExplicitAny: mock client doesn't implement full FakturoidClient interface
 		const result = await executeSmartCreateExpense(mockClient as any, {
 			registration_no: "87654321",
 			original_number: "FV-2026-002",
 		});
 
-		expect((result as any).status).toBe("created");
-		expect((result as any).subject.status).toBe("created");
+		expect(result).not.toBeInstanceOf(Error);
+		if (result instanceof Error) {
+			throw result;
+		}
+		expect(result.status).toBe("created");
+		expect(result.subject.status).toBe("created");
 	});
 
 	it("returns duplicate when original_number already exists for subject", async () => {
-		const subject = { id: 42, name: "Supplier Co", registration_no: "12345678" };
-		mockResolveSubject.mockResolvedValue({ status: "found", data: subject as any });
+		const subject = { id: 42, name: "Supplier Co", registration_no: "12345678" } as Subject;
+		mockResolveSubject.mockResolvedValue({ status: "found", data: subject });
 		const existingExpense = { id: 5, original_number: "FV-2026-001", subject_id: 42 };
 		const otherExpense = { id: 6, original_number: "FV-2026-999", subject_id: 42 };
 		mockClient.getExpenses.mockResolvedValue([otherExpense, existingExpense]);
 
+		// biome-ignore lint/suspicious/noExplicitAny: mock client doesn't implement full FakturoidClient interface
 		const result = await executeSmartCreateExpense(mockClient as any, {
 			registration_no: "12345678",
 			original_number: "FV-2026-001",
@@ -85,25 +93,31 @@ describe("executeSmartCreateExpense", () => {
 	});
 
 	it("skips duplicate check when original_number is not provided", async () => {
-		const subject = { id: 42, name: "Supplier Co", registration_no: "12345678" };
-		mockResolveSubject.mockResolvedValue({ status: "found", data: subject as any });
+		const subject = { id: 42, name: "Supplier Co", registration_no: "12345678" } as Subject;
+		mockResolveSubject.mockResolvedValue({ status: "found", data: subject });
 		const createdExpense = { id: 3, subject_id: 42 };
 		mockClient.createExpense.mockResolvedValue(createdExpense);
 
+		// biome-ignore lint/suspicious/noExplicitAny: mock client doesn't implement full FakturoidClient interface
 		const result = await executeSmartCreateExpense(mockClient as any, {
 			registration_no: "12345678",
 		});
 
-		expect((result as any).status).toBe("created");
+		expect(result).not.toBeInstanceOf(Error);
+		if (result instanceof Error) {
+			throw result;
+		}
+		expect(result.status).toBe("created");
 		expect(mockClient.getExpenses).not.toHaveBeenCalled();
 	});
 
 	it("resolves subject as supplier type", async () => {
-		const subject = { id: 42, name: "Supplier Co", registration_no: "12345678" };
-		mockResolveSubject.mockResolvedValue({ status: "found", data: subject as any });
+		const subject = { id: 42, name: "Supplier Co", registration_no: "12345678" } as Subject;
+		mockResolveSubject.mockResolvedValue({ status: "found", data: subject });
 		mockClient.getExpenses.mockResolvedValue([]);
 		mockClient.createExpense.mockResolvedValue({ id: 1, subject_id: 42 });
 
+		// biome-ignore lint/suspicious/noExplicitAny: mock client doesn't implement full FakturoidClient interface
 		await executeSmartCreateExpense(mockClient as any, {
 			registration_no: "12345678",
 		});
@@ -114,6 +128,7 @@ describe("executeSmartCreateExpense", () => {
 	it("returns error when subject resolution fails", async () => {
 		mockResolveSubject.mockResolvedValue(new Error("API error"));
 
+		// biome-ignore lint/suspicious/noExplicitAny: mock client doesn't implement full FakturoidClient interface
 		const result = await executeSmartCreateExpense(mockClient as any, {
 			registration_no: "12345678",
 		});
@@ -122,11 +137,12 @@ describe("executeSmartCreateExpense", () => {
 	});
 
 	it("returns error when expense creation fails", async () => {
-		const subject = { id: 42, name: "Supplier Co", registration_no: "12345678" };
-		mockResolveSubject.mockResolvedValue({ status: "found", data: subject as any });
+		const subject = { id: 42, name: "Supplier Co", registration_no: "12345678" } as Subject;
+		mockResolveSubject.mockResolvedValue({ status: "found", data: subject });
 		mockClient.getExpenses.mockResolvedValue([]);
 		mockClient.createExpense.mockResolvedValue(new Error("Validation error"));
 
+		// biome-ignore lint/suspicious/noExplicitAny: mock client doesn't implement full FakturoidClient interface
 		const result = await executeSmartCreateExpense(mockClient as any, {
 			registration_no: "12345678",
 			original_number: "FV-2026-001",

--- a/src/fakturoid/tool/smartExpense.test.ts
+++ b/src/fakturoid/tool/smartExpense.test.ts
@@ -77,7 +77,8 @@ describe("executeSmartCreateExpense", () => {
 			subject: { status: "found", data: subject },
 			document: {
 				data: existingExpense,
-				message: "Document with this number already exists for this subject. Ask the user whether to update it or leave it as-is.",
+				message:
+					"Document with this number already exists for this subject. Ask the user whether to update it or leave it as-is.",
 			},
 		});
 		expect(mockClient.createExpense).not.toHaveBeenCalled();

--- a/src/fakturoid/tool/smartExpense.test.ts
+++ b/src/fakturoid/tool/smartExpense.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./resolveSubject.js", () => ({
+	resolveSubject: vi.fn(),
+}));
+
+import { resolveSubject } from "./resolveSubject.js";
+import { executeSmartCreateExpense } from "./smartExpense.js";
+
+const mockClient = {
+	getExpenses: vi.fn(),
+	createExpense: vi.fn(),
+};
+
+const mockResolveSubject = vi.mocked(resolveSubject);
+
+describe("executeSmartCreateExpense", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("creates expense when subject exists and no duplicate", async () => {
+		const subject = { id: 42, name: "Supplier Co", registration_no: "12345678" };
+		mockResolveSubject.mockResolvedValue({ status: "found", data: subject as any });
+		mockClient.getExpenses.mockResolvedValue([]);
+		const createdExpense = { id: 1, original_number: "FV-2026-001", subject_id: 42 };
+		mockClient.createExpense.mockResolvedValue(createdExpense);
+
+		const result = await executeSmartCreateExpense(mockClient as any, {
+			registration_no: "12345678",
+			original_number: "FV-2026-001",
+			lines: [{ name: "Material", unit_price: "500", quantity: "1", vat_rate: 21 }],
+		});
+
+		expect(result).toEqual({
+			status: "created",
+			subject: { status: "found", data: subject },
+			document: { data: createdExpense },
+		});
+		expect(mockClient.createExpense).toHaveBeenCalledWith({
+			subject_id: 42,
+			original_number: "FV-2026-001",
+			lines: [{ name: "Material", unit_price: "500", quantity: "1", vat_rate: 21 }],
+		});
+	});
+
+	it("creates subject and expense when subject not found", async () => {
+		const subject = { id: 99, name: "New Supplier", registration_no: "87654321" };
+		mockResolveSubject.mockResolvedValue({ status: "created", data: subject as any });
+		mockClient.getExpenses.mockResolvedValue([]);
+		const createdExpense = { id: 2, original_number: "FV-2026-002", subject_id: 99 };
+		mockClient.createExpense.mockResolvedValue(createdExpense);
+
+		const result = await executeSmartCreateExpense(mockClient as any, {
+			registration_no: "87654321",
+			original_number: "FV-2026-002",
+		});
+
+		expect((result as any).status).toBe("created");
+		expect((result as any).subject.status).toBe("created");
+	});
+
+	it("returns duplicate when original_number already exists for subject", async () => {
+		const subject = { id: 42, name: "Supplier Co", registration_no: "12345678" };
+		mockResolveSubject.mockResolvedValue({ status: "found", data: subject as any });
+		const existingExpense = { id: 5, original_number: "FV-2026-001", subject_id: 42 };
+		const otherExpense = { id: 6, original_number: "FV-2026-999", subject_id: 42 };
+		mockClient.getExpenses.mockResolvedValue([otherExpense, existingExpense]);
+
+		const result = await executeSmartCreateExpense(mockClient as any, {
+			registration_no: "12345678",
+			original_number: "FV-2026-001",
+		});
+
+		expect(result).toEqual({
+			status: "duplicate_found",
+			subject: { status: "found", data: subject },
+			document: {
+				data: existingExpense,
+				message: "Document with this number already exists for this subject. Ask the user whether to update it or leave it as-is.",
+			},
+		});
+		expect(mockClient.createExpense).not.toHaveBeenCalled();
+	});
+
+	it("skips duplicate check when original_number is not provided", async () => {
+		const subject = { id: 42, name: "Supplier Co", registration_no: "12345678" };
+		mockResolveSubject.mockResolvedValue({ status: "found", data: subject as any });
+		const createdExpense = { id: 3, subject_id: 42 };
+		mockClient.createExpense.mockResolvedValue(createdExpense);
+
+		const result = await executeSmartCreateExpense(mockClient as any, {
+			registration_no: "12345678",
+		});
+
+		expect((result as any).status).toBe("created");
+		expect(mockClient.getExpenses).not.toHaveBeenCalled();
+	});
+
+	it("resolves subject as supplier type", async () => {
+		const subject = { id: 42, name: "Supplier Co", registration_no: "12345678" };
+		mockResolveSubject.mockResolvedValue({ status: "found", data: subject as any });
+		mockClient.getExpenses.mockResolvedValue([]);
+		mockClient.createExpense.mockResolvedValue({ id: 1, subject_id: 42 });
+
+		await executeSmartCreateExpense(mockClient as any, {
+			registration_no: "12345678",
+		});
+
+		expect(mockResolveSubject).toHaveBeenCalledWith(mockClient, "12345678", "supplier");
+	});
+
+	it("returns error when subject resolution fails", async () => {
+		mockResolveSubject.mockResolvedValue(new Error("API error"));
+
+		const result = await executeSmartCreateExpense(mockClient as any, {
+			registration_no: "12345678",
+		});
+
+		expect(result).toBeInstanceOf(Error);
+	});
+
+	it("returns error when expense creation fails", async () => {
+		const subject = { id: 42, name: "Supplier Co", registration_no: "12345678" };
+		mockResolveSubject.mockResolvedValue({ status: "found", data: subject as any });
+		mockClient.getExpenses.mockResolvedValue([]);
+		mockClient.createExpense.mockResolvedValue(new Error("Validation error"));
+
+		const result = await executeSmartCreateExpense(mockClient as any, {
+			registration_no: "12345678",
+			original_number: "FV-2026-001",
+		});
+
+		expect(result).toBeInstanceOf(Error);
+	});
+});

--- a/src/fakturoid/tool/smartExpense.ts
+++ b/src/fakturoid/tool/smartExpense.ts
@@ -1,0 +1,104 @@
+import { z } from "zod/v3";
+import type { FakturoidClient } from "../client.js";
+import type { Expense } from "../model/expense.js";
+import { CreateExpenseSchema } from "../model/expense.js";
+import { createTool, type ServerToolCreator } from "./common.js";
+import { resolveSubject, type SubjectResolution } from "./resolveSubject.js";
+
+type SmartCreateExpenseResult =
+	| {
+			status: "created" | "duplicate_found";
+			subject: SubjectResolution;
+			document: {
+				data: Expense;
+				message?: string;
+			};
+	  }
+	| Error;
+
+const DUPLICATE_MESSAGE =
+	"Document with this number already exists for this subject. Ask the user whether to update it or leave it as-is.";
+
+const SmartCreateExpenseInputSchema = CreateExpenseSchema.omit({ subject_id: true }).extend({
+	registration_no: z.string().describe("Registration number (IČO) of the subject"),
+});
+
+type SmartCreateExpenseInput = z.infer<typeof SmartCreateExpenseInputSchema>;
+
+const executeSmartCreateExpense = async (
+	client: FakturoidClient<any, any>,
+	input: SmartCreateExpenseInput,
+): Promise<SmartCreateExpenseResult> => {
+	const { registration_no, ...expenseData } = input;
+
+	const subjectResult = await resolveSubject(client, registration_no, "supplier");
+	if (subjectResult instanceof Error) {
+		return subjectResult;
+	}
+
+	const subjectId = subjectResult.data.id;
+
+	if (expenseData.original_number != null) {
+		const existingExpenses = await client.getExpenses({
+			subject_id: subjectId,
+		});
+
+		if (existingExpenses instanceof Error) {
+			return new Error(`Expense search failed: ${existingExpenses.message}`);
+		}
+
+		const duplicate = existingExpenses.find(
+			(e) => e.original_number === expenseData.original_number,
+		);
+
+		if (duplicate != null) {
+			return {
+				status: "duplicate_found",
+				subject: subjectResult,
+				document: {
+					data: duplicate as Expense,
+					message: DUPLICATE_MESSAGE,
+				},
+			};
+		}
+	}
+
+	const created = await client.createExpense({
+		...expenseData,
+		subject_id: subjectId,
+	});
+
+	if (created instanceof Error) {
+		return new Error(`Expense creation failed: ${created.message}`);
+	}
+
+	return {
+		status: "created",
+		subject: subjectResult,
+		document: { data: created },
+	};
+};
+
+const smartCreateExpense = createTool(
+	"fakturoid_smart_create_expense",
+	"Smart Create Expense",
+	"Resolve subject by IČO (create via ARES if not found), check for duplicate expense by original number, and create the expense — all in one step. Returns existing document with a message if duplicate is found.",
+	async (client, input) => {
+		const result = await executeSmartCreateExpense(client, input as SmartCreateExpenseInput);
+
+		if (result instanceof Error) {
+			return {
+				content: [{ isError: true, text: result.message, type: "text" as const }],
+			};
+		}
+
+		return {
+			content: [{ text: JSON.stringify(result, null, 2), type: "text" as const }],
+		};
+	},
+	SmartCreateExpenseInputSchema.shape,
+);
+
+const smartExpense = [smartCreateExpense] as const satisfies ServerToolCreator[];
+
+export { smartExpense, executeSmartCreateExpense };

--- a/src/fakturoid/tool/smartExpense.ts
+++ b/src/fakturoid/tool/smartExpense.ts
@@ -1,4 +1,5 @@
 import { z } from "zod/v3";
+import type { AuthenticationStrategy } from "../../auth/strategy.js";
 import type { FakturoidClient } from "../client.js";
 import type { Expense } from "../model/expense.js";
 import { CreateExpenseSchema } from "../model/expense.js";
@@ -25,8 +26,11 @@ const SmartCreateExpenseInputSchema = CreateExpenseSchema.omit({ subject_id: tru
 
 type SmartCreateExpenseInput = z.infer<typeof SmartCreateExpenseInputSchema>;
 
-const executeSmartCreateExpense = async (
-	client: FakturoidClient<any, any>,
+const executeSmartCreateExpense = async <
+	Configuration extends object = object,
+	Strategy extends AuthenticationStrategy<Configuration> = AuthenticationStrategy<Configuration>,
+>(
+	client: FakturoidClient<Configuration, Strategy>,
 	input: SmartCreateExpenseInput,
 ): Promise<SmartCreateExpenseResult> => {
 	const { registration_no, ...expenseData } = input;

--- a/src/fakturoid/tool/smartExpense.ts
+++ b/src/fakturoid/tool/smartExpense.ts
@@ -47,9 +47,7 @@ const executeSmartCreateExpense = async (
 			return new Error(`Expense search failed: ${existingExpenses.message}`);
 		}
 
-		const duplicate = existingExpenses.find(
-			(e) => e.original_number === expenseData.original_number,
-		);
+		const duplicate = existingExpenses.find((e) => e.original_number === expenseData.original_number);
 
 		if (duplicate != null) {
 			return {

--- a/src/fakturoid/tool/smartInvoice.test.ts
+++ b/src/fakturoid/tool/smartInvoice.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./resolveSubject.js", () => ({
+	resolveSubject: vi.fn(),
+}));
+
+import { resolveSubject } from "./resolveSubject.js";
+import { executeSmartCreateInvoice } from "./smartInvoice.js";
+
+const mockClient = {
+	getInvoices: vi.fn(),
+	createInvoice: vi.fn(),
+};
+
+const mockResolveSubject = vi.mocked(resolveSubject);
+
+describe("executeSmartCreateInvoice", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+	it("creates invoice when subject exists and no duplicate", async () => {
+		const subject = { id: 42, name: "Test Co", registration_no: "12345678" };
+		mockResolveSubject.mockResolvedValue({ status: "found", data: subject as any });
+		mockClient.getInvoices.mockResolvedValue([]);
+		const createdInvoice = { id: 1, number: "2026-001", subject_id: 42 };
+		mockClient.createInvoice.mockResolvedValue(createdInvoice);
+
+		const result = await executeSmartCreateInvoice(mockClient as any, {
+			registration_no: "12345678",
+			number: "2026-001",
+			lines: [{ name: "Service", unit_price: "1000", quantity: "1", vat_rate: 21 }],
+		});
+
+		expect(result).toEqual({
+			status: "created",
+			subject: { status: "found", data: subject },
+			document: { data: createdInvoice },
+		});
+		expect(mockClient.createInvoice).toHaveBeenCalledWith({
+			subject_id: 42,
+			number: "2026-001",
+			lines: [{ name: "Service", unit_price: "1000", quantity: "1", vat_rate: 21 }],
+		});
+	});
+
+	it("creates subject and invoice when subject not found", async () => {
+		const subject = { id: 99, name: "New Co", registration_no: "87654321" };
+		mockResolveSubject.mockResolvedValue({ status: "created", data: subject as any });
+		mockClient.getInvoices.mockResolvedValue([]);
+		const createdInvoice = { id: 2, number: "2026-002", subject_id: 99 };
+		mockClient.createInvoice.mockResolvedValue(createdInvoice);
+
+		const result = await executeSmartCreateInvoice(mockClient as any, {
+			registration_no: "87654321",
+			number: "2026-002",
+		});
+
+		expect((result as any).status).toBe("created");
+		expect((result as any).subject.status).toBe("created");
+	});
+
+	it("returns duplicate when invoice number already exists for subject", async () => {
+		const subject = { id: 42, name: "Test Co", registration_no: "12345678" };
+		mockResolveSubject.mockResolvedValue({ status: "found", data: subject as any });
+		const existingInvoice = { id: 5, number: "2026-001", subject_id: 42 };
+		mockClient.getInvoices.mockResolvedValue([existingInvoice]);
+
+		const result = await executeSmartCreateInvoice(mockClient as any, {
+			registration_no: "12345678",
+			number: "2026-001",
+		});
+
+		expect(result).toEqual({
+			status: "duplicate_found",
+			subject: { status: "found", data: subject },
+			document: {
+				data: existingInvoice,
+				message: "Document with this number already exists for this subject. Ask the user whether to update it or leave it as-is.",
+			},
+		});
+		expect(mockClient.createInvoice).not.toHaveBeenCalled();
+	});
+
+	it("skips duplicate check when number is not provided", async () => {
+		const subject = { id: 42, name: "Test Co", registration_no: "12345678" };
+		mockResolveSubject.mockResolvedValue({ status: "found", data: subject as any });
+		const createdInvoice = { id: 3, subject_id: 42 };
+		mockClient.createInvoice.mockResolvedValue(createdInvoice);
+
+		const result = await executeSmartCreateInvoice(mockClient as any, {
+			registration_no: "12345678",
+		});
+
+		expect((result as any).status).toBe("created");
+		expect(mockClient.getInvoices).not.toHaveBeenCalled();
+	});
+
+	it("returns error when subject resolution fails", async () => {
+		mockResolveSubject.mockResolvedValue(new Error("API error"));
+
+		const result = await executeSmartCreateInvoice(mockClient as any, {
+			registration_no: "12345678",
+		});
+
+		expect(result).toBeInstanceOf(Error);
+	});
+
+	it("returns error when invoice creation fails", async () => {
+		const subject = { id: 42, name: "Test Co", registration_no: "12345678" };
+		mockResolveSubject.mockResolvedValue({ status: "found", data: subject as any });
+		mockClient.getInvoices.mockResolvedValue([]);
+		mockClient.createInvoice.mockResolvedValue(new Error("Validation error"));
+
+		const result = await executeSmartCreateInvoice(mockClient as any, {
+			registration_no: "12345678",
+			number: "2026-001",
+		});
+
+		expect(result).toBeInstanceOf(Error);
+	});
+});

--- a/src/fakturoid/tool/smartInvoice.test.ts
+++ b/src/fakturoid/tool/smartInvoice.test.ts
@@ -4,6 +4,7 @@ vi.mock("./resolveSubject.js", () => ({
 	resolveSubject: vi.fn(),
 }));
 
+import type { Subject } from "../model/subject.js";
 import { resolveSubject } from "./resolveSubject.js";
 import { executeSmartCreateInvoice } from "./smartInvoice.js";
 
@@ -19,12 +20,13 @@ describe("executeSmartCreateInvoice", () => {
 		vi.clearAllMocks();
 	});
 	it("creates invoice when subject exists and no duplicate", async () => {
-		const subject = { id: 42, name: "Test Co", registration_no: "12345678" };
-		mockResolveSubject.mockResolvedValue({ status: "found", data: subject as any });
+		const subject = { id: 42, name: "Test Co", registration_no: "12345678" } as Subject;
+		mockResolveSubject.mockResolvedValue({ status: "found", data: subject });
 		mockClient.getInvoices.mockResolvedValue([]);
 		const createdInvoice = { id: 1, number: "2026-001", subject_id: 42 };
 		mockClient.createInvoice.mockResolvedValue(createdInvoice);
 
+		// biome-ignore lint/suspicious/noExplicitAny: mock client doesn't implement full FakturoidClient interface
 		const result = await executeSmartCreateInvoice(mockClient as any, {
 			registration_no: "12345678",
 			number: "2026-001",
@@ -44,27 +46,33 @@ describe("executeSmartCreateInvoice", () => {
 	});
 
 	it("creates subject and invoice when subject not found", async () => {
-		const subject = { id: 99, name: "New Co", registration_no: "87654321" };
-		mockResolveSubject.mockResolvedValue({ status: "created", data: subject as any });
+		const subject = { id: 99, name: "New Co", registration_no: "87654321" } as Subject;
+		mockResolveSubject.mockResolvedValue({ status: "created", data: subject });
 		mockClient.getInvoices.mockResolvedValue([]);
 		const createdInvoice = { id: 2, number: "2026-002", subject_id: 99 };
 		mockClient.createInvoice.mockResolvedValue(createdInvoice);
 
+		// biome-ignore lint/suspicious/noExplicitAny: mock client doesn't implement full FakturoidClient interface
 		const result = await executeSmartCreateInvoice(mockClient as any, {
 			registration_no: "87654321",
 			number: "2026-002",
 		});
 
-		expect((result as any).status).toBe("created");
-		expect((result as any).subject.status).toBe("created");
+		expect(result).not.toBeInstanceOf(Error);
+		if (result instanceof Error) {
+			throw result;
+		}
+		expect(result.status).toBe("created");
+		expect(result.subject.status).toBe("created");
 	});
 
 	it("returns duplicate when invoice number already exists for subject", async () => {
-		const subject = { id: 42, name: "Test Co", registration_no: "12345678" };
-		mockResolveSubject.mockResolvedValue({ status: "found", data: subject as any });
+		const subject = { id: 42, name: "Test Co", registration_no: "12345678" } as Subject;
+		mockResolveSubject.mockResolvedValue({ status: "found", data: subject });
 		const existingInvoice = { id: 5, number: "2026-001", subject_id: 42 };
 		mockClient.getInvoices.mockResolvedValue([existingInvoice]);
 
+		// biome-ignore lint/suspicious/noExplicitAny: mock client doesn't implement full FakturoidClient interface
 		const result = await executeSmartCreateInvoice(mockClient as any, {
 			registration_no: "12345678",
 			number: "2026-001",
@@ -83,22 +91,28 @@ describe("executeSmartCreateInvoice", () => {
 	});
 
 	it("skips duplicate check when number is not provided", async () => {
-		const subject = { id: 42, name: "Test Co", registration_no: "12345678" };
-		mockResolveSubject.mockResolvedValue({ status: "found", data: subject as any });
+		const subject = { id: 42, name: "Test Co", registration_no: "12345678" } as Subject;
+		mockResolveSubject.mockResolvedValue({ status: "found", data: subject });
 		const createdInvoice = { id: 3, subject_id: 42 };
 		mockClient.createInvoice.mockResolvedValue(createdInvoice);
 
+		// biome-ignore lint/suspicious/noExplicitAny: mock client doesn't implement full FakturoidClient interface
 		const result = await executeSmartCreateInvoice(mockClient as any, {
 			registration_no: "12345678",
 		});
 
-		expect((result as any).status).toBe("created");
+		expect(result).not.toBeInstanceOf(Error);
+		if (result instanceof Error) {
+			throw result;
+		}
+		expect(result.status).toBe("created");
 		expect(mockClient.getInvoices).not.toHaveBeenCalled();
 	});
 
 	it("returns error when subject resolution fails", async () => {
 		mockResolveSubject.mockResolvedValue(new Error("API error"));
 
+		// biome-ignore lint/suspicious/noExplicitAny: mock client doesn't implement full FakturoidClient interface
 		const result = await executeSmartCreateInvoice(mockClient as any, {
 			registration_no: "12345678",
 		});
@@ -107,11 +121,12 @@ describe("executeSmartCreateInvoice", () => {
 	});
 
 	it("returns error when invoice creation fails", async () => {
-		const subject = { id: 42, name: "Test Co", registration_no: "12345678" };
-		mockResolveSubject.mockResolvedValue({ status: "found", data: subject as any });
+		const subject = { id: 42, name: "Test Co", registration_no: "12345678" } as Subject;
+		mockResolveSubject.mockResolvedValue({ status: "found", data: subject });
 		mockClient.getInvoices.mockResolvedValue([]);
 		mockClient.createInvoice.mockResolvedValue(new Error("Validation error"));
 
+		// biome-ignore lint/suspicious/noExplicitAny: mock client doesn't implement full FakturoidClient interface
 		const result = await executeSmartCreateInvoice(mockClient as any, {
 			registration_no: "12345678",
 			number: "2026-001",

--- a/src/fakturoid/tool/smartInvoice.test.ts
+++ b/src/fakturoid/tool/smartInvoice.test.ts
@@ -75,7 +75,8 @@ describe("executeSmartCreateInvoice", () => {
 			subject: { status: "found", data: subject },
 			document: {
 				data: existingInvoice,
-				message: "Document with this number already exists for this subject. Ask the user whether to update it or leave it as-is.",
+				message:
+					"Document with this number already exists for this subject. Ask the user whether to update it or leave it as-is.",
 			},
 		});
 		expect(mockClient.createInvoice).not.toHaveBeenCalled();

--- a/src/fakturoid/tool/smartInvoice.ts
+++ b/src/fakturoid/tool/smartInvoice.ts
@@ -1,4 +1,5 @@
 import { z } from "zod/v3";
+import type { AuthenticationStrategy } from "../../auth/strategy.js";
 import type { FakturoidClient } from "../client.js";
 import type { Invoice } from "../model/invoice.js";
 import { CreateInvoiceSchema } from "../model/invoice.js";
@@ -25,8 +26,11 @@ const SmartCreateInvoiceInputSchema = CreateInvoiceSchema.omit({ subject_id: tru
 
 type SmartCreateInvoiceInput = z.infer<typeof SmartCreateInvoiceInputSchema>;
 
-const executeSmartCreateInvoice = async (
-	client: FakturoidClient<any, any>,
+const executeSmartCreateInvoice = async <
+	Configuration extends object = object,
+	Strategy extends AuthenticationStrategy<Configuration> = AuthenticationStrategy<Configuration>,
+>(
+	client: FakturoidClient<Configuration, Strategy>,
 	input: SmartCreateInvoiceInput,
 ): Promise<SmartCreateInvoiceResult> => {
 	const { registration_no, ...invoiceData } = input;

--- a/src/fakturoid/tool/smartInvoice.ts
+++ b/src/fakturoid/tool/smartInvoice.ts
@@ -1,0 +1,101 @@
+import { z } from "zod/v3";
+import type { FakturoidClient } from "../client.js";
+import type { Invoice } from "../model/invoice.js";
+import { CreateInvoiceSchema } from "../model/invoice.js";
+import { createTool, type ServerToolCreator } from "./common.js";
+import { resolveSubject, type SubjectResolution } from "./resolveSubject.js";
+
+type SmartCreateInvoiceResult =
+	| {
+			status: "created" | "duplicate_found";
+			subject: SubjectResolution;
+			document: {
+				data: Invoice;
+				message?: string;
+			};
+	  }
+	| Error;
+
+const DUPLICATE_MESSAGE =
+	"Document with this number already exists for this subject. Ask the user whether to update it or leave it as-is.";
+
+const SmartCreateInvoiceInputSchema = CreateInvoiceSchema.omit({ subject_id: true }).extend({
+	registration_no: z.string().describe("Registration number (IČO) of the subject"),
+});
+
+type SmartCreateInvoiceInput = z.infer<typeof SmartCreateInvoiceInputSchema>;
+
+const executeSmartCreateInvoice = async (
+	client: FakturoidClient<any, any>,
+	input: SmartCreateInvoiceInput,
+): Promise<SmartCreateInvoiceResult> => {
+	const { registration_no, ...invoiceData } = input;
+
+	const subjectResult = await resolveSubject(client, registration_no, "customer");
+	if (subjectResult instanceof Error) {
+		return subjectResult;
+	}
+
+	const subjectId = subjectResult.data.id;
+
+	if (invoiceData.number != null) {
+		const existingInvoices = await client.getInvoices({
+			subject_id: subjectId,
+			number: invoiceData.number,
+		});
+
+		if (existingInvoices instanceof Error) {
+			return new Error(`Invoice search failed: ${existingInvoices.message}`);
+		}
+
+		if (existingInvoices.length > 0) {
+			return {
+				status: "duplicate_found",
+				subject: subjectResult,
+				document: {
+					data: existingInvoices[0] as Invoice,
+					message: DUPLICATE_MESSAGE,
+				},
+			};
+		}
+	}
+
+	const created = await client.createInvoice({
+		...invoiceData,
+		subject_id: subjectId,
+	});
+
+	if (created instanceof Error) {
+		return new Error(`Invoice creation failed: ${created.message}`);
+	}
+
+	return {
+		status: "created",
+		subject: subjectResult,
+		document: { data: created },
+	};
+};
+
+const smartCreateInvoice = createTool(
+	"fakturoid_smart_create_invoice",
+	"Smart Create Invoice",
+	"Resolve subject by IČO (create via ARES if not found), check for duplicate invoice by number, and create the invoice — all in one step. Returns existing document with a message if duplicate is found.",
+	async (client, input) => {
+		const result = await executeSmartCreateInvoice(client, input as SmartCreateInvoiceInput);
+
+		if (result instanceof Error) {
+			return {
+				content: [{ isError: true, text: result.message, type: "text" as const }],
+			};
+		}
+
+		return {
+			content: [{ text: JSON.stringify(result, null, 2), type: "text" as const }],
+		};
+	},
+	SmartCreateInvoiceInputSchema.shape,
+);
+
+const smartInvoice = [smartCreateInvoice] as const satisfies ServerToolCreator[];
+
+export { smartInvoice, executeSmartCreateInvoice };

--- a/src/fakturoid/tools.ts
+++ b/src/fakturoid/tools.ts
@@ -17,6 +17,8 @@ import { invoicePayment } from "./tool/invoicePayment.js";
 import { meta } from "./tool/meta.js";
 import { numberFormat } from "./tool/numberFormat.js";
 import { recurringGenerator } from "./tool/recurringGenerator.js";
+import { smartExpense } from "./tool/smartExpense.js";
+import { smartInvoice } from "./tool/smartInvoice.js";
 import { subject } from "./tool/subject.js";
 import { todo } from "./tool/todo.js";
 import { user } from "./tool/user.js";
@@ -45,6 +47,8 @@ const registerFakturoidTools = <
 		meta,
 		numberFormat,
 		recurringGenerator,
+		smartExpense,
+		smartInvoice,
 		subject,
 		todo,
 		user,


### PR DESCRIPTION
## Summary

- Adds two compound MCP tools (`fakturoid_smart_create_invoice`, `fakturoid_smart_create_expense`) that encapsulate subject resolution, duplicate detection, and document creation into a single tool call
- Subject resolution searches by IČO, creates via ARES auto-fill if not found
- Duplicate detection returns existing document with a message for the AI agent to ask the user whether to update or skip
- Reduces token usage and round-trips from 3-4 tool calls down to 1

## New files

| File | Purpose |
|---|---|
| `src/fakturoid/tool/resolveSubject.ts` | Shared helper: search subject by IČO, create if not found |
| `src/fakturoid/tool/smartInvoice.ts` | `fakturoid_smart_create_invoice` tool |
| `src/fakturoid/tool/smartExpense.ts` | `fakturoid_smart_create_expense` tool |

## Test plan

- [x] 6 unit tests for subject resolution helper (found, create, different IČO, supplier type, search error, create error)
- [x] 6 unit tests for smart invoice tool (create, new subject, duplicate, no number, subject error, create error)
- [x] 7 unit tests for smart expense tool (create, new subject, duplicate with client-side filtering, no original_number, supplier type, subject error, create error)
- [x] All 184 tests pass
- [ ] Manual test with MCP Inspector against a real Fakturoid account

🤖 Generated with [Claude Code](https://claude.com/claude-code)