### PR TITLE
fix: point logs to stderr

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -7,6 +7,7 @@ const DEVELOPMENT_OPTIONS = {
 		level: "debug",
 		options: {
 			colorize: true,
+			destination: 2,
 		},
 		target: "pino-pretty",
 	},


### PR DESCRIPTION
Since the stdout is used for the communication, we must follow the best practice and log to stderr